### PR TITLE
Omit CLI from test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -226,6 +226,7 @@ branch = true
 source_pkgs = ["geogenalg"]
 # TODO: remove omit section when qgis dependencies removed/function refactored
 omit = [
+    "src/geogenalg/main.py",
     "src/geogenalg/application/generalize_lakes.py",
     "src/geogenalg/application/generalize_seas.py",
     "src/geogenalg/buffer/exaggerate_thin_parts.py",


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

It was decided that the CLI functions don't need their own unit tests since they just expose individual algorithms to use in command line. This PR fixes the test coverage check by omitting `main.py` from checked modules.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [ ] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
