### PR TITLE
refactor(BaseAlgorithm): make reference_data None by default

### DIFF
--- a/src/geogenalg/application/__init__.py
+++ b/src/geogenalg/application/__init__.py
@@ -24,7 +24,7 @@ class BaseAlgorithm(ABC):
     def execute(
         self,
         data: GeoDataFrame,
-        reference_data: dict[str, GeoDataFrame],
+        reference_data: dict[str, GeoDataFrame] | None = None,
     ) -> GeoDataFrame:
         """Execute the algorithm.
 
@@ -42,6 +42,9 @@ class BaseAlgorithm(ABC):
         # to rely on the assumption that input index is some kind of string
         if not is_string_dtype(data.index.dtype):
             data = data.set_index(data.index.astype("string"))
+
+        if reference_data is None:
+            reference_data = {}
 
         output = self._execute(data=data, reference_data=reference_data)
 


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Make `reference_data` None by default in `BaseAlgorithm.execute`, turn to empty dict when calling `_execute`, so algorithms don't have to deal with it possibly being None.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
