### PR TITLE
Cli input concat

### DIFF
--- a/src/geogenalg/application/generalize_buildings.py
+++ b/src/geogenalg/application/generalize_buildings.py
@@ -80,8 +80,6 @@ class GeneralizeBuildings(BaseAlgorithm):
     """Building classes always represented as points."""
     classes_for_always_kept_buildings: frozenset[int | str] = frozenset()
     """Building classes that are always retained, regardless of thresholds."""
-    unique_key_column: str = "id"
-    """Column name containing the unique identifier."""
     building_class_column: str = "building_function"
     """Column name containing the building class information."""
     original_area_column: str = "original_area"

--- a/src/geogenalg/main.py
+++ b/src/geogenalg/main.py
@@ -173,6 +173,21 @@ def named_geopackage_uri(value: str) -> NamedGeoPackageURI:
     return NamedGeoPackageURI(name=name, uri=uri)
 
 
+def input_geopackage_uris(value: str) -> list[GeoPackageURI]:
+    """Parse string into a list of GeoPackageURIs.
+
+    Args:
+    ----
+        value: string to parse
+
+    Returns:
+    -------
+        List of GeoPackageURIs.
+
+    """
+    return [geopackage_uri(uri) for uri in value.split("+")]
+
+
 def int_or_str_list(value: str) -> int | str:
     """Parse string into an int if possible, keep as is otherwise.
 
@@ -281,6 +296,20 @@ def get_basealgorithm_attribute_docstrings(cls: type[BaseAlgorithm]) -> dict[str
     return output
 
 
+MultipleGeoPackagesArgument = Annotated[
+    GeoPackageURI,
+    typer.Argument(
+        parser=input_geopackage_uris,
+        help="Path(s) to a GeoPackage, with layer name optionally specified, "
+        + 'examples: "my_geopackage.gpkg" "my_geopackage.gpkg|my_layer_name". '
+        + "You can also specify multiple inputs by delimiting them with the '+' "
+        + 'symbol ("my_geopackage.gpkg@layer+other_geopackage.gpkg@other_layer"). '
+        + "In this case the given inputs will be combined. This can be "
+        + "used to f.e. combine datasets with different geometry types to use "
+        + "with algorithms which accept multiple geometry types.",
+    ),
+]
+
 GeoPackageArgument = Annotated[
     GeoPackageURI,
     typer.Argument(
@@ -318,7 +347,10 @@ def _function_generator(algorithm: type[BaseAlgorithm]) -> FunctionType:
     ) -> None:
         args = kwargs
 
-        input_geopackage = cast("GeoPackageArgument", args.pop("input_geopackage"))
+        input_geopackages = cast(
+            "list[GeoPackageURI]",
+            args.pop("input_geopackages"),
+        )
         output_geopackage = cast("GeoPackageArgument", args.pop("output_geopackage"))
         unique_id_column = cast("str", args.pop("unique_id_column"))
 
@@ -348,14 +380,20 @@ def _function_generator(algorithm: type[BaseAlgorithm]) -> FunctionType:
 
         instance = algorithm(**kwargs)
 
-        if unique_id_column is not None:
-            in_gdf = read_gdf_from_file_and_set_index(
-                input_geopackage.file,
-                unique_id_column,
-                layer=input_geopackage.layer_name,
-            )
-        else:
-            in_gdf = read_file(input_geopackage.file, layer=input_geopackage.layer_name)
+        input_gdfs = []
+        for uri in input_geopackages:
+            if unique_id_column is not None:
+                in_gdf = read_gdf_from_file_and_set_index(
+                    uri.file,
+                    unique_id_column,
+                    layer=uri.layer_name,
+                )
+            else:
+                in_gdf = read_file(uri.file, layer=uri.layer_name)
+
+            input_gdfs.append(in_gdf)
+
+        in_gdf = input_gdfs[0] if len(input_gdfs) == 1 else combine_gdfs(input_gdfs)
 
         output = instance.execute(in_gdf, reference_data=reference_data)
         output.to_file(output_geopackage.file, layer=output_geopackage.layer_name)
@@ -406,9 +444,9 @@ def build_app() -> None:  # noqa: PLR0914
 
         parameters = [
             Parameter(
-                name="input_geopackage",
+                name="input_geopackages",
                 kind=Parameter.POSITIONAL_OR_KEYWORD,
-                annotation=GeoPackageArgument,
+                annotation=MultipleGeoPackagesArgument,
             ),
             Parameter(
                 name="output_geopackage",

--- a/src/geogenalg/main.py
+++ b/src/geogenalg/main.py
@@ -58,8 +58,9 @@ from geogenalg.utility.dataframe_processing import (
 )
 
 GEOPACKAGE_URI_HELP = (
-    "Path to a GeoPackage, with layer name optionally specified, "
-    + 'examples: "my_geopackage.gpkg" "my_geopackage.gpkg|my_layer_name"'
+    "Path to a GeoPackage, with layer name optionally specified after a @ or | symbol, "
+    + 'examples: "my_geopackage.gpkg" "my_geopackage.gpkg@my_layer_name" '
+    + '"file.gpkg|layer"'
 )
 
 
@@ -300,9 +301,8 @@ MultipleGeoPackagesArgument = Annotated[
     GeoPackageURI,
     typer.Argument(
         parser=input_geopackage_uris,
-        help="Path(s) to a GeoPackage, with layer name optionally specified, "
-        + 'examples: "my_geopackage.gpkg" "my_geopackage.gpkg|my_layer_name". '
-        + "You can also specify multiple inputs by delimiting them with the '+' "
+        help=GEOPACKAGE_URI_HELP
+        + ". You can also specify multiple inputs by delimiting them with the '+' "
         + 'symbol ("my_geopackage.gpkg@layer+other_geopackage.gpkg@other_layer"). '
         + "In this case the given inputs will be combined. This can be "
         + "used to f.e. combine datasets with different geometry types to use "

--- a/test/application/test_generalize_buildings.py
+++ b/test/application/test_generalize_buildings.py
@@ -46,7 +46,6 @@ def test_generalize_buildings_50k(testdata_path: Path) -> None:
             classes_for_low_priority_buildings=frozenset([6, 4]),
             classes_for_point_buildings=frozenset([8]),
             classes_for_always_kept_buildings=frozenset(),
-            unique_key_column="mtk_id",
             building_class_column="kayttotarkoitus",
             original_area_column="original_area",
             main_angle_column="main_angle",
@@ -72,7 +71,6 @@ def test_generalize_buildings_100k(testdata_path: Path) -> None:
             classes_for_low_priority_buildings=frozenset([6, 4]),
             classes_for_point_buildings=frozenset([8]),
             classes_for_always_kept_buildings=frozenset(),
-            unique_key_column="mtk_id",
             building_class_column="kayttotarkoitus",
             original_area_column="original_area",
             main_angle_column="main_angle",
@@ -187,7 +185,6 @@ def test_filter_buildings_by_area_and_class(
         minimum_distance_to_isolated_building=10,
         hole_threshold=10,
         classes_for_point_buildings=frozenset([3, 2]),
-        unique_key_column="id",
     )
 
     result_gdf = alg._filter_buildings_by_area_and_class(input_gdf)
@@ -252,7 +249,6 @@ def test_filter_buildings_by_area_and_class_with_varied_geometries(
         minimum_distance_to_isolated_building=10,
         hole_threshold=10,
         classes_for_point_buildings=frozenset([3, 2]),
-        unique_key_column="id",
     )
     result_gdf = alg._filter_buildings_by_area_and_class(gdf)
 

--- a/test/test_main.py
+++ b/test/test_main.py
@@ -18,6 +18,7 @@ from geogenalg.main import (
     geopackage_uri,
     get_basealgorithm_attribute_docstrings,
     get_class_attribute_docstrings,
+    input_geopackage_uris,
     int_or_str_list,
     named_geopackage_uri,
 )
@@ -212,3 +213,35 @@ def test_main():
 )
 def test_int_or_str_list(input_string: str, expected: NamedGeoPackageURI):
     assert int_or_str_list(input_string) == expected
+
+
+@pytest.mark.parametrize(
+    ("input_string", "expected"),
+    [
+        (
+            "/path/to/geopackage.gpkg+/path/to/other/geopackage.gpkg@layer_name+relative.gpkg|lyr",
+            [
+                GeoPackageURI(file="/path/to/geopackage.gpkg", layer_name=None),
+                GeoPackageURI(
+                    file="/path/to/other/geopackage.gpkg", layer_name="layer_name"
+                ),
+                GeoPackageURI(file="relative.gpkg", layer_name="lyr"),
+            ],
+        ),
+        (
+            "/path/to/geopackage.gpkg|layer",
+            [GeoPackageURI(file="/path/to/geopackage.gpkg", layer_name="layer")],
+        ),
+        (
+            '"/path/to/geopackage.gpkg|layer"',
+            [GeoPackageURI(file="/path/to/geopackage.gpkg", layer_name="layer")],
+        ),
+    ],
+    ids=[
+        "multiple",
+        "with layer",
+        "quotes",
+    ],
+)
+def test_input_geopackage_uris(input_string: str, expected: GeoPackageURI):
+    assert input_geopackage_uris(input_string) == expected

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -40,6 +40,7 @@ geodataframe
 geogenalg
 geoms
 geopackage
+geopackages
 geopandas
 geoseries
 getfullargspec


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Allow specifying multiple GeoPackage paths for algorithm input data by delimiting by `+`, i.e.

```shell
generalize buildings point_buildings.gpkg@layer+polygon_buildings.gpkg@layer out.gpkg ...
```

Data sources are combined to a single GDF and passed to the algorithm.

The main motivation for this change is to make entering data with different geometry types through the CLI easier. This is needed for at least `GeneralizeBuildings`.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
