### PR TITLE
fix(continuity): handle single line case in _get_merged_line_connections

### DIFF
--- a/src/geogenalg/continuity.py
+++ b/src/geogenalg/continuity.py
@@ -760,9 +760,14 @@ def _get_merged_line_connections(
     input_gdf: GeoDataFrame,
     reference_network: GeoDataFrame,
 ) -> GeoDataFrame:
+    merged_geom = input_gdf.union_all()
+
+    if isinstance(merged_geom, MultiLineString):
+        merged_geom = linemerge(merged_geom)
+
     merged = GeoDataFrame(
         geometry=[
-            linemerge(input_gdf.union_all()),
+            merged_geom,
         ],
         crs=input_gdf.crs,
     ).explode()

--- a/test/test_continuity.py
+++ b/test/test_continuity.py
@@ -1408,12 +1408,67 @@ def test_process_lines_and_reconnect(
                 ],
             ),
         ),
+        (
+            GeoDataFrame(  # single_line
+                {
+                    "type": [
+                        1,
+                    ],
+                },
+                geometry=[
+                    LineString([[0, 0], [1, 0]]),
+                ],
+            ),
+            GeoDataFrame(geometry=[]),
+            100.0,
+            "type",
+            GeoDataFrame(
+                {
+                    "type": [
+                        1,
+                    ],
+                    "contiguous_dead_end": [
+                        False,
+                    ],
+                    "contiguous_disconnected": [
+                        True,
+                    ],
+                    "contiguous_length": [
+                        1.0,
+                    ],
+                },
+                geometry=[
+                    LineString([[0, 0], [1, 0]]),
+                ],
+            ),
+        ),
+        (
+            GeoDataFrame({"type": []}),  # empty_input
+            GeoDataFrame(geometry=[]),
+            100.0,
+            "type",
+            GeoDataFrame({"type": []}),
+        ),
+        (
+            GeoDataFrame({"type": []}),  # empty_input_non_empty_reference
+            GeoDataFrame(
+                geometry=[
+                    LineString([[0, 0], [1, 0]]),
+                ],
+            ),
+            100.0,
+            "type",
+            GeoDataFrame({"type": []}),
+        ),
     ],
     ids=[
         "has_some_dead_ends",
         "network",
         "disconnected",
         "line_type_column",
+        "single_line",
+        "empty_input",
+        "empty_input_non_empty_reference",
     ],
 )
 def test_add_contiguous_lines_information(


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Don't try to `linemerge` single `LineString`

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

- [ ] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
