### PR TITLE
Linestring continuity smoothing

### DIFF
--- a/src/geogenalg/continuity.py
+++ b/src/geogenalg/continuity.py
@@ -25,7 +25,7 @@ from geogenalg.core.geometry import (
     get_topological_points,
     split_linear_geometry,
 )
-from geogenalg.utility.dataframe_processing import combine_gdfs
+from geogenalg.utility.dataframe_processing import combine_gdfs, copy_gdf_as_empty
 
 
 def find_all_endpoints(
@@ -939,7 +939,7 @@ def smooth_contiguously(
 
     """
     if input_gdf.empty:
-        return input_gdf[0:0].copy()
+        return copy_gdf_as_empty(input_gdf)
 
     gdf = GeoDataFrame(
         geometry=[

--- a/src/geogenalg/continuity.py
+++ b/src/geogenalg/continuity.py
@@ -9,21 +9,19 @@ from itertools import starmap
 from typing import Literal, cast
 
 from geopandas import GeoDataFrame
-from geopandas.geoseries import GeoSeries
 from pandas import Series
 from shapely import force_2d
 from shapely.geometry import LineString, MultiLineString, Point, Polygon
 from shapely.geometry.base import BaseGeometry
 from shapely.ops import linemerge
-from shapelysmooth import chaikin_smooth
 
 from geogenalg.core.exceptions import GeometryOperationError
 from geogenalg.core.geometry import (
     LineExtendFrom,
-    extend_line_by,
     extend_line_to_nearest,
     get_topological_points,
-    split_linear_geometry,
+    smooth_around_connection_point_of_two_lines,
+    smooth_around_ring_closing_vertex,
 )
 from geogenalg.utility.dataframe_processing import combine_gdfs, copy_gdf_as_empty
 
@@ -921,17 +919,17 @@ def get_segments_in_polygon_exteriors_but_not_in_lines(
     )
 
 
-def smooth_contiguously(
+def smooth_linestring_connections(
     input_gdf: GeoDataFrame,
     *,
-    iterations: int = 5,
+    spline_subdivisions: int = 10,
 ) -> GeoDataFrame:
-    """Smooth lines in a GeoDataFrame without retaining feature ends.
+    """Smooth segments around connection points of two lines.
 
     Args:
     ----
         input_gdf: GeoDataFrame with lines.
-        iterations: How many smoothing passes are performed.
+        spline_subdivisions: How many vertices are added to smoothed segments.
 
     Returns:
     -------
@@ -941,42 +939,30 @@ def smooth_contiguously(
     if input_gdf.empty:
         return copy_gdf_as_empty(input_gdf)
 
-    gdf = GeoDataFrame(
-        geometry=[
-            linemerge(input_gdf.union_all()),
-        ],
-        crs=input_gdf.crs,
-    ).explode()
+    gdf = input_gdf.copy()
+
+    points = get_topological_points(input_gdf.geometry, force_2d=False)
+
+    for point in points:
+        intersecting_lines = gdf.loc[gdf.geometry.intersects(point)]
+
+        if intersecting_lines.shape[0] != 2:  # noqa: PLR2004
+            continue
+
+        smoothed_line_1, smoothed_line_2 = smooth_around_connection_point_of_two_lines(
+            intersecting_lines.geometry.to_numpy()[0],
+            intersecting_lines.geometry.to_numpy()[1],
+            point,
+            spline_subdivisions=spline_subdivisions,
+        )
+
+        gdf.geometry.at[intersecting_lines.index.to_numpy()[0]] = smoothed_line_1  # noqa: PD008
+        gdf.geometry.at[intersecting_lines.index.to_numpy()[1]] = smoothed_line_2  # noqa: PD008
 
     gdf.geometry = gdf.geometry.apply(
-        lambda geom: chaikin_smooth(geom, iterations, keep_ends=not geom.is_ring),
+        lambda geom: smooth_around_ring_closing_vertex(
+            geom, spline_subdivisions=spline_subdivisions
+        )
     )
 
-    splitters = GeoSeries(
-        get_topological_points(input_gdf.geometry),
-        crs=input_gdf.crs,
-    ).to_frame()
-    splitters.geometry = splitters.geometry.shortest_line(gdf.union_all())
-    splitters.geometry = splitters.geometry.apply(
-        lambda geom: extend_line_by(geom, 5, LineExtendFrom.BOTH)
-    )
-
-    gdf["__splitter"] = gdf.geometry.apply(
-        lambda geom: splitters.loc[splitters.geometry.intersects(geom)].union_all()
-    )
-
-    gdf.geometry = gdf[[gdf.geometry.name, "__splitter"]].apply(
-        lambda columns: split_linear_geometry(
-            columns[gdf.geometry.name],
-            columns["__splitter"],
-        ),
-        axis=1,
-    )
-    gdf = gdf.drop("__splitter", axis=1)
-    gdf = gdf.explode()
-
-    index_name = (
-        input_gdf.index.name if input_gdf.index.name is not None else "index_right"
-    )
-
-    return gdf.sjoin_nearest(input_gdf).set_index(index_name)
+    return gdf

--- a/src/geogenalg/core/geometry.py
+++ b/src/geogenalg/core/geometry.py
@@ -1305,7 +1305,7 @@ def ramer_douglas_peucker_simplify_keep_coords(
 
 def insert_vertex(
     geom: LineString | LinearRing,
-    vertex: Point | tuple[float, float] | tuple[float, float, float],
+    vertex: Point | tuple[float, ...],
     index: int,
 ) -> LineString:
     """Insert vertex to a linear geometry at given index.
@@ -1326,25 +1326,29 @@ def insert_vertex(
     """
     coords = list(geom.coords)
 
-    if isinstance(vertex, Point):
-        if geom.has_z:
-            coords.insert(
-                index,
-                (
-                    vertex.x,
-                    vertex.y,
-                    vertex.z if vertex.has_z else 0.0,
-                ),
-            )
-        else:
-            coords.insert(
-                index,
-                (vertex.x, vertex.y),
-            )
+    def _interpolate_z() -> float:
+        if index <= 0:
+            return coords[0][2]
+
+        if index >= len(coords):
+            return coords[len(coords) - 1][2]
+
+        return (coords[index - 1][2] + coords[index][2]) / 2
+
+    vertex_as_tuple = vertex.coords[0] if isinstance(vertex, Point) else vertex
+
+    vertex_has_z = len(vertex_as_tuple) == 3  # noqa: PLR2004
+    if geom.has_z:
+        z = vertex_as_tuple[2] if vertex_has_z else _interpolate_z()
+
+        coords.insert(index, (vertex_as_tuple[0], vertex_as_tuple[1], z))
     else:
         coords.insert(
             index,
-            vertex,
+            (
+                vertex_as_tuple[0],
+                vertex_as_tuple[1],
+            ),
         )
 
     return LineString(coords)
@@ -1529,42 +1533,38 @@ def smooth_around_ring_closing_vertex(
         subdivs=spline_subdivisions,
     )
 
-    cut_vertexes_per_side_count = 1
-    smoothed_vertex_count = cut_vertexes_per_side_count * spline_subdivisions
-
-    line_cut = line.coords[
-        cut_vertexes_per_side_count : len(line.coords) - cut_vertexes_per_side_count
-    ]
-
-    if len(line_cut) < 2:  # noqa: PLR2004
-        return line
-
-    line_cut = LineString(line_cut)
-
     before_vertices = [
         _get_vertex_circular(smoothed_line.coords, i)
-        for i in range(-smoothed_vertex_count, 1)
+        for i in range(-spline_subdivisions, 1)
     ]
     after_vertices = [
         _get_vertex_circular(smoothed_line.coords, i)
-        for i in range(smoothed_vertex_count)
+        for i in range(spline_subdivisions)
     ]
     after_vertices.reverse()
 
+    modified_line = line
+
     for vertex in before_vertices:
         vertex_with_z_handled = vertex if not line.has_z else (vertex[0], vertex[1], 0)
-        line_cut = insert_vertex(
-            line_cut, vertex_with_z_handled, len(line_cut.coords) + 1
+        modified_line = insert_vertex(
+            modified_line,
+            vertex_with_z_handled,
+            len(modified_line.coords) - 1,
         )
 
     for vertex in after_vertices:
         vertex_with_z_handled = vertex if not line.has_z else (vertex[0], vertex[1], 0)
-        line_cut = insert_vertex(line_cut, vertex_with_z_handled, 0)
+        modified_line = insert_vertex(
+            modified_line,
+            vertex_with_z_handled,
+            1,
+        )
 
-    return remove_repeated_points(line_cut)
+    return remove_repeated_points(modified_line)
 
 
-def smooth_around_connection_point_of_two_lines(  # noqa: C901, PLR0912, PLR0914
+def smooth_around_connection_point_of_two_lines(  # noqa: C901
     line_1: LineString,
     line_2: LineString,
     point: Point,
@@ -1618,16 +1618,13 @@ def smooth_around_connection_point_of_two_lines(  # noqa: C901, PLR0912, PLR0914
         subdivs=spline_subdivisions,
     )
 
-    cut_vertexes_per_side_count = 1
-    smoothed_vertex_count = cut_vertexes_per_side_count * spline_subdivisions
-
     before_vertices = [
         _get_vertex_circular(smoothed_combined_line.coords, i)
-        for i in range(cut_index - smoothed_vertex_count, cut_index + 1)
+        for i in range(cut_index - spline_subdivisions, cut_index + 1)
     ]
     after_vertices = [
         _get_vertex_circular(smoothed_combined_line.coords, i)
-        for i in range(cut_index, cut_index + smoothed_vertex_count)
+        for i in range(cut_index, cut_index + spline_subdivisions)
     ]
     after_vertices.reverse()
 
@@ -1639,21 +1636,6 @@ def smooth_around_connection_point_of_two_lines(  # noqa: C901, PLR0912, PLR0914
         if not smooth_start and not smooth_end:
             continue
 
-        total_vertices = len(line.coords)
-
-        line_cut = line.coords[
-            cut_vertexes_per_side_count if smooth_start else 0 : total_vertices
-            - cut_vertexes_per_side_count
-            if smooth_end
-            else total_vertices
-        ]
-
-        if len(line_cut) < 2:  # noqa: PLR2004
-            warn("Could not cut line properly, not smoothing line.", stacklevel=2)
-            smoothed_lines.append(line)
-            continue
-        line_cut = LineString(line_cut)
-
         before_in_coords = vertex_before in line.coords
         after_in_coords = vertex_after in line.coords
         if before_in_coords and not after_in_coords:
@@ -1662,29 +1644,24 @@ def smooth_around_connection_point_of_two_lines(  # noqa: C901, PLR0912, PLR0914
             chosen_vertices = after_vertices
         else:
             warn(
-                "Could not determine where from to add vertices from, "
+                "Could not determine where from to add vertices, "
                 + "not smoothing line.",
                 stacklevel=2,
             )
             smoothed_lines.append(line)
             continue
 
-        if smooth_end:
-            for vertex in chosen_vertices:
-                vertex_with_z_handled = (
-                    vertex if not line.has_z else (vertex[0], vertex[1], 0)
-                )
-                line_cut = insert_vertex(
-                    line_cut, vertex_with_z_handled, len(line_cut.coords) + 1
-                )
+        modified_line = line
+        for vertex in chosen_vertices:
+            vertex_with_z_handled = (
+                vertex if not line.has_z else (vertex[0], vertex[1], 0)
+            )
+            modified_line = insert_vertex(
+                modified_line,
+                vertex_with_z_handled,
+                len(modified_line.coords) - 1 if smooth_end else 1,
+            )
 
-        if smooth_start:
-            for vertex in chosen_vertices:
-                vertex_with_z_handled = (
-                    vertex if not line.has_z else (vertex[0], vertex[1], 0)
-                )
-                line_cut = insert_vertex(line_cut, vertex_with_z_handled, 0)
-
-        smoothed_lines.append(remove_repeated_points(line_cut))
+        smoothed_lines.append(remove_repeated_points(modified_line))
 
     return tuple(smoothed_lines)

--- a/src/geogenalg/core/geometry.py
+++ b/src/geogenalg/core/geometry.py
@@ -10,6 +10,7 @@ from itertools import chain
 from math import atan2, degrees, pi, sqrt
 from statistics import mean
 from typing import Literal, NamedTuple
+from warnings import warn
 
 from geopandas import GeoDataFrame, GeoSeries
 from numpy import array, column_stack, ndarray, vstack  # noqa: SC200
@@ -29,6 +30,7 @@ from shapely import (
     get_coordinates,
     length,
     polygonize,
+    remove_repeated_points,
     shortest_line,
 )
 from shapely.affinity import rotate, scale, translate
@@ -36,6 +38,7 @@ from shapely.coords import CoordinateSequence
 from shapely.geometry import LinearRing
 from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
 from shapely.ops import linemerge, nearest_points, split
+from shapelysmooth import catmull_rom_smooth
 
 from geogenalg.core.exceptions import (
     GeometryOperationError,
@@ -172,7 +175,11 @@ def chaikin_smooth_skip_coords(
     return result
 
 
-def get_topological_points(geoseries: GeoSeries) -> list[Point]:
+def get_topological_points(
+    geoseries: GeoSeries,
+    *,
+    force_2d: bool = True,
+) -> list[Point]:
     """Find all topological points in a GeoSeries.
 
     Topological point referring to a point which is shared by two or more
@@ -181,6 +188,7 @@ def get_topological_points(geoseries: GeoSeries) -> list[Point]:
     Args:
     ----
         geoseries: The GeoSeries to find topological points in.
+        force_2d: Whether to find and return points as 2d geometries.
 
     Returns:
     -------
@@ -195,7 +203,10 @@ def get_topological_points(geoseries: GeoSeries) -> list[Point]:
     if geoseries.empty:
         return []
 
-    unique_points = geoseries.force_2d().extract_unique_points().union_all()
+    if force_2d:
+        unique_points = geoseries.force_2d().extract_unique_points().union_all()
+    else:
+        unique_points = geoseries.extract_unique_points().union_all()
 
     if isinstance(unique_points, Point):
         unique_points = MultiPoint([unique_points])
@@ -1294,7 +1305,7 @@ def ramer_douglas_peucker_simplify_keep_coords(
 
 def insert_vertex(
     geom: LineString | LinearRing,
-    vertex: Point,
+    vertex: Point | tuple[float, float] | tuple[float, float, float],
     index: int,
 ) -> LineString:
     """Insert vertex to a linear geometry at given index.
@@ -1314,20 +1325,27 @@ def insert_vertex(
 
     """
     coords = list(geom.coords)
-    vertex_as_tuple: tuple[float, float] | tuple[float, float, float]
-    if geom.has_z:
-        vertex_as_tuple = (
-            vertex.x,
-            vertex.y,
-            vertex.z if vertex.has_z else 0.0,
-        )
-    else:
-        vertex_as_tuple = (
-            vertex.x,
-            vertex.y,
-        )
 
-    coords.insert(index, vertex_as_tuple)
+    if isinstance(vertex, Point):
+        if geom.has_z:
+            coords.insert(
+                index,
+                (
+                    vertex.x,
+                    vertex.y,
+                    vertex.z if vertex.has_z else 0.0,
+                ),
+            )
+        else:
+            coords.insert(
+                index,
+                (vertex.x, vertex.y),
+            )
+    else:
+        coords.insert(
+            index,
+            vertex,
+        )
 
     return LineString(coords)
 
@@ -1463,3 +1481,210 @@ def snap_to_closest_vertex_or_segment(
         snap_point = Point(snap_point.x, snap_point.y, point.z)
 
     return snap_point
+
+
+def _get_vertex_circular(coords: CoordinateSequence, index: int) -> tuple[float, ...]:
+    """Get vertex while handling overflowing index by looping around to the start.
+
+    Returns
+    -------
+        Vertex at given index.
+
+    """
+    if index < 0:
+        return coords[index]
+
+    if index < len(coords):
+        return coords[index]
+
+    return coords[(index % len(coords)) + 1]
+
+
+def smooth_around_ring_closing_vertex(
+    line: LineString,
+    *,
+    spline_subdivisions: int = 10,
+) -> LineString:
+    """Smooth segments around closing vertex of closed linestring.
+
+    If `line` is invalid or not closed it is returned as is.
+    If line has z coordinates, smoothed vertices will default to 0.0.
+
+    Args:
+    ----
+        line: Line to smooth.
+        spline_subdivisions: How many vertices are added to smoothed segments.
+
+    Returns:
+    -------
+        Smoothed line (provided it was possible to smooth).
+
+    """
+    if not line.is_closed or not line.is_valid:
+        return line
+
+    smoothed_line = catmull_rom_smooth(
+        force_2d(line),
+        0.5,
+        subdivs=spline_subdivisions,
+    )
+
+    cut_vertexes_per_side_count = 1
+    smoothed_vertex_count = cut_vertexes_per_side_count * spline_subdivisions
+
+    line_cut = line.coords[
+        cut_vertexes_per_side_count : len(line.coords) - cut_vertexes_per_side_count
+    ]
+
+    if len(line_cut) < 2:  # noqa: PLR2004
+        return line
+
+    line_cut = LineString(line_cut)
+
+    before_vertices = [
+        _get_vertex_circular(smoothed_line.coords, i)
+        for i in range(-smoothed_vertex_count, 1)
+    ]
+    after_vertices = [
+        _get_vertex_circular(smoothed_line.coords, i)
+        for i in range(smoothed_vertex_count)
+    ]
+    after_vertices.reverse()
+
+    for vertex in before_vertices:
+        vertex_with_z_handled = vertex if not line.has_z else (vertex[0], vertex[1], 0)
+        line_cut = insert_vertex(
+            line_cut, vertex_with_z_handled, len(line_cut.coords) + 1
+        )
+
+    for vertex in after_vertices:
+        vertex_with_z_handled = vertex if not line.has_z else (vertex[0], vertex[1], 0)
+        line_cut = insert_vertex(line_cut, vertex_with_z_handled, 0)
+
+    return remove_repeated_points(line_cut)
+
+
+def smooth_around_connection_point_of_two_lines(  # noqa: C901, PLR0912, PLR0914
+    line_1: LineString,
+    line_2: LineString,
+    point: Point,
+    *,
+    spline_subdivisions: int = 10,
+) -> tuple[LineString, LineString]:
+    """Smooth segments in given lines which are around the given point.
+
+    If line has z coordinates, smoothed vertices will default to 0.0.
+
+    Args:
+    ----
+        line_1: Line to smooth.
+        line_2: Line to smooth.
+        point: Point around which segments are smoothed.
+        spline_subdivisions: How many vertices are added to smoothed segments.
+
+    Returns:
+    -------
+        Smoothed lines (provided they could be smoothed) in this order:
+        (line_1, line_2).
+
+    """
+    if not line_1.touches(line_2.boundary):
+        return line_1, line_2
+
+    if not point.intersects(line_1) or not point.intersects(line_2):
+        return line_1, line_2
+
+    combined_line = linemerge([line_1, line_2])
+
+    cut_index = -1
+    for i, vertex in enumerate(combined_line.coords):
+        if point.coords[0] == vertex:
+            cut_index = i
+
+    if cut_index == -1:
+        warn("Did not find matching vertex in combined line.", stacklevel=2)
+        return line_1, line_2
+
+    vertex_before = _get_vertex_circular(combined_line.coords, cut_index - 1)
+    vertex_after = _get_vertex_circular(combined_line.coords, cut_index + 1)
+
+    cut_index *= spline_subdivisions
+
+    # Use Catmull-Rom spline because it's not going to shift existing
+    # coordinates and is guaranteed to travel through them
+    smoothed_combined_line = catmull_rom_smooth(
+        force_2d(combined_line),
+        0.5,
+        subdivs=spline_subdivisions,
+    )
+
+    cut_vertexes_per_side_count = 1
+    smoothed_vertex_count = cut_vertexes_per_side_count * spline_subdivisions
+
+    before_vertices = [
+        _get_vertex_circular(smoothed_combined_line.coords, i)
+        for i in range(cut_index - smoothed_vertex_count, cut_index + 1)
+    ]
+    after_vertices = [
+        _get_vertex_circular(smoothed_combined_line.coords, i)
+        for i in range(cut_index, cut_index + smoothed_vertex_count)
+    ]
+    after_vertices.reverse()
+
+    smoothed_lines = []
+    for line in (line_1, line_2):
+        smooth_start = point.coords[0] == line.coords[0]
+        smooth_end = point.coords[0] == line.coords[-1]
+
+        if not smooth_start and not smooth_end:
+            continue
+
+        total_vertices = len(line.coords)
+
+        line_cut = line.coords[
+            cut_vertexes_per_side_count if smooth_start else 0 : total_vertices
+            - cut_vertexes_per_side_count
+            if smooth_end
+            else total_vertices
+        ]
+
+        if len(line_cut) < 2:  # noqa: PLR2004
+            warn("Could not cut line properly, not smoothing line.", stacklevel=2)
+            smoothed_lines.append(line)
+            continue
+        line_cut = LineString(line_cut)
+
+        before_in_coords = vertex_before in line.coords
+        after_in_coords = vertex_after in line.coords
+        if before_in_coords and not after_in_coords:
+            chosen_vertices = before_vertices
+        elif after_in_coords and not before_in_coords:
+            chosen_vertices = after_vertices
+        else:
+            warn(
+                "Could not determine where from to add vertices from, "
+                + "not smoothing line.",
+                stacklevel=2,
+            )
+            smoothed_lines.append(line)
+            continue
+
+        if smooth_end:
+            for vertex in chosen_vertices:
+                vertex_with_z_handled = (
+                    vertex if not line.has_z else (vertex[0], vertex[1], 0)
+                )
+                line_cut = insert_vertex(
+                    line_cut, vertex_with_z_handled, len(line_cut.coords) + 1
+                )
+
+        if smooth_start:
+            for vertex in chosen_vertices:
+                vertex_with_z_handled = (
+                    vertex if not line.has_z else (vertex[0], vertex[1], 0)
+                )
+                line_cut = insert_vertex(line_cut, vertex_with_z_handled, 0)
+
+        smoothed_lines.append(remove_repeated_points(line_cut))
+
+    return tuple(smoothed_lines)

--- a/src/geogenalg/core/geometry.py
+++ b/src/geogenalg/core/geometry.py
@@ -3,7 +3,8 @@
 #  This file is part of geogen-algorithms.
 #
 #  SPDX-License-Identifier: MIT
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
+from copy import deepcopy
 from enum import Enum
 from itertools import chain
 from math import atan2, degrees, pi, sqrt
@@ -34,7 +35,7 @@ from shapely.affinity import rotate, scale, translate
 from shapely.coords import CoordinateSequence
 from shapely.geometry import LinearRing
 from shapely.geometry.base import BaseGeometry, BaseMultipartGeometry
-from shapely.ops import linemerge, split
+from shapely.ops import linemerge, nearest_points, split
 
 from geogenalg.core.exceptions import (
     GeometryOperationError,
@@ -684,19 +685,18 @@ def extend_line_by(
     if extend_from == LineExtendFrom.END:
         point = point_on_line(last_segment, extend_by)
 
-        return extend_line_to_nearest(line, point, extend_from)
+        return insert_vertex(line, point, len(line.coords) + 1)
 
     if extend_from == LineExtendFrom.START:
         point = point_on_line(first_segment, -extend_by)
 
-        return extend_line_to_nearest(line, point, extend_from)
+        return insert_vertex(line, point, 0)
 
     point_1 = point_on_line(first_segment, -extend_by)
     point_2 = point_on_line(last_segment, extend_by)
 
-    multi_point = MultiPoint((point_1, point_2))
-
-    return extend_line_to_nearest(line, multi_point, extend_from)
+    new_line = insert_vertex(line, point_1, 0)
+    return insert_vertex(new_line, point_2, len(line.coords) + 1)
 
 
 def _geometry_with_z_from_kd_tree(  # noqa: PLR0911, SC200
@@ -1147,8 +1147,8 @@ def split_linear_geometry(  # noqa: C901
 
     Returns
     -------
-        Processed geometry, always as a MultiLineString (even if no splitting)
-        occurred.
+        Processed geometry, always as a MultiLineString (even if no splitting
+        occurred).
 
     Raises
     ------
@@ -1200,7 +1200,7 @@ def split_linear_geometry(  # noqa: C901
         raise GeometryOperationError(msg)
 
     # Extra part does not occur always, if geom is split to a correct number of
-    # parts already, retun already.
+    # parts already, return early
     if len(diff.geoms) == len(splits_at.geoms):
         return diff
 
@@ -1215,3 +1215,251 @@ def split_linear_geometry(  # noqa: C901
         raise GeometryOperationError(msg)
 
     return MultiLineString(parts)
+
+
+def ramer_douglas_peucker_simplify_keep_coords(
+    geom: LineString,
+    tolerance: float,
+    keep_coords: set[Point],
+) -> LineString:
+    """Simplify linestring.
+
+    This is an implementation of the Ramer-Douglas-Peucker algorithm which
+    performs simplification of linear geometries. As an addition this
+    implementation allows to specify coordinates which will always be kept no
+    matter what.
+
+    Args:
+    ----
+        geom: Geometry to smooth.
+        tolerance: Distance parameter used in algorithm, higher value will result
+            in more vertices being removed.
+        keep_coords: Set of points to keep. If a corresponding coordinate exists
+            in the input geometry, it is guaranteed to remain unchanged. If the set
+            is empty, shapely's simplify function is used instead.
+
+    Returns:
+    -------
+        Smoothed geometry.
+
+    Note:
+    ----
+        If keeping of coordinates is not required, prefer shapely's simplify
+        function as it uses the same algorithm and is faster.
+
+    """
+    if not keep_coords:
+        return geom.simplify(tolerance)
+
+    CoordList = list[tuple[float, float]]  # noqa: N806
+
+    def rdp(coords: CoordList) -> CoordList:
+        furthest_distance = 0.0
+        furthest_point_index = -1
+
+        if len(coords) < 3:  # noqa: PLR2004
+            return coords
+
+        start_point = Point(coords[0])
+        end_point = Point(coords[-1])
+
+        for i in range(1, len(coords) - 1):
+            current_point = Point(coords[i])
+            if current_point in keep_coords:
+                furthest_distance = tolerance + 1
+                furthest_point_index = i
+                break
+
+            distance = current_point.distance(LineString([start_point, end_point]))
+
+            if distance > furthest_distance:
+                furthest_distance = distance
+                furthest_point_index = i
+
+        if furthest_distance > tolerance:
+            line_1 = rdp(coords[0 : furthest_point_index + 1])
+            line_2 = rdp(coords[furthest_point_index:])
+
+            return line_1[:-1] + line_2
+
+        return [
+            start_point.coords[0],
+            end_point.coords[0],
+        ]
+
+    coords = rdp(list(geom.coords))
+
+    return LineString(coords)
+
+
+def insert_vertex(
+    geom: LineString | LinearRing,
+    vertex: Point,
+    index: int,
+) -> LineString:
+    """Insert vertex to a linear geometry at given index.
+
+    If `geom` has z values but the vertex does not, the z coordinate for the
+    added vertex will default to 0.0.
+
+    Args:
+    ----
+        geom: Geometry to add the vertex to.
+        vertex: The vertex to add.
+        index: The index at which to insert the vertex. Must be a valid index.
+
+    Returns:
+    -------
+        Geometry with added vertex.
+
+    """
+    coords = list(geom.coords)
+    vertex_as_tuple: tuple[float, float] | tuple[float, float, float]
+    if geom.has_z:
+        vertex_as_tuple = (
+            vertex.x,
+            vertex.y,
+            vertex.z if vertex.has_z else 0.0,
+        )
+    else:
+        vertex_as_tuple = (
+            vertex.x,
+            vertex.y,
+        )
+
+    coords.insert(index, vertex_as_tuple)
+
+    return LineString(coords)
+
+
+def add_topological_point(
+    geom: LineString,
+    point: Point,
+    tolerance: float = 0.0,
+) -> LineString:
+    """Add new vertex to geometry if it resides on a segment.
+
+    If `point` does not intersect any segment (at the given distance tolerance)
+    the geometry is returned unchanged.
+
+    If `point` is already a vertex in the geometry it is not added.
+
+    Args:
+    ----
+        geom: Geometry to add vertices to.
+        point: Point to add to `geom`.
+        tolerance: Maximum distance the point can be off a segment.
+
+    Returns:
+    -------
+        Geometry with added vertex, or unchanged geometry if point was not on a
+        segment.
+
+    Raises:
+    ------
+        ValueError: If tolerance is below zero.
+
+    """
+    if tolerance < 0:
+        msg = "Tolerance should be 0 or above."
+        raise ValueError(msg)
+
+    # TODO: implement for polygons/multigeoms?
+    segments = explode_line(geom).geoms
+
+    point_2d = force_2d(point)
+    intersects_check_geom = point if tolerance == 0 else point.buffer(tolerance)
+
+    vertex_index = 0
+    for i in range(len(segments)):
+        segment = segments[i]
+        point_1 = force_2d(Point(segment.coords[0]))
+        point_2 = force_2d(Point(segment.coords[1]))
+
+        if not intersects_check_geom.intersects(segment) or point_2d in {
+            point_1,
+            point_2,
+        }:
+            vertex_index += 2
+            continue
+
+        return insert_vertex(geom, point, i + 1)
+
+    return geom
+
+
+def add_topological_points(
+    geom: LineString,
+    points: Iterable[Point],
+    tolerance: float = 0.0,
+) -> LineString:
+    """Add new vertices to geometry if they reside on a segment.
+
+    If a point does not intersect any segment it is not added to the geometry.
+
+    If a point is already a vertex in the geometry it is not added.
+
+    Args:
+    ----
+        geom: Geometry to add vertices to.
+        points: Points to add to `geom`.
+        tolerance: Maximum distance a point can be off a segment.
+
+    Returns:
+    -------
+        Geometry with added vertices (if any).
+
+    Raises:
+    ------
+        ValueError: If tolerance is below zero.
+
+    """
+    if tolerance < 0:
+        msg = "Tolerance should be 0 or above."
+        raise ValueError(msg)
+
+    # TODO: implement for polygons/multigeoms?
+    processed_geom = deepcopy(geom)
+    for point in points:
+        processed_geom = add_topological_point(processed_geom, point, tolerance)
+
+    return processed_geom
+
+
+def snap_to_closest_vertex_or_segment(
+    point: Point,
+    snap_to: BaseGeometry,
+    tolerance: float = 0.0,
+    z_behavior: Literal["inherit", "exclude"] = "inherit",
+) -> Point:
+    """Return point snapped to closest vertex or segment in reference geometry.
+
+    The difference to shapely's snap function is that it only snaps to vertices,
+    whereas this also snaps to segments.
+
+    Args:
+    ----
+        point: Point geometry to snap.
+        snap_to: Geometry to snap to.
+        tolerance: Maximum distance to snapped point. If distance is above this,
+            the point is returned unchanged.
+        z_behavior: Describes what should happen if input point has a z
+            coordinate. If "inherit", the snapped point will get input point's z
+            coordinate, if "exclude" the snapped point will not have a z
+            coordinate.
+
+
+    Returns:
+    -------
+        Snapped point if it was within the distance tolerance, otherwise the
+        unchanged point.
+
+    """
+    _, snap_point = nearest_points(point, snap_to)
+    if point.distance(snap_point) < tolerance:
+        return point
+
+    if z_behavior == "inherit" and point.has_z:
+        snap_point = Point(snap_point.x, snap_point.y, point.z)
+
+    return snap_point

--- a/src/geogenalg/main.py
+++ b/src/geogenalg/main.py
@@ -573,6 +573,7 @@ def build_app() -> None:  # noqa: PLR0914
             parameters=parameters
         )
 
+        app.pretty_exceptions_show_locals = False
         app.command(help=alg.__doc__)(algorithm_command_function)
 
 

--- a/test/core/test_geometry.py
+++ b/test/core/test_geometry.py
@@ -40,6 +40,8 @@ from geogenalg.core.exceptions import (
 from geogenalg.core.geometry import (
     Dimensions,
     LineExtendFrom,
+    add_topological_point,
+    add_topological_points,
     assign_nearest_z,
     centerline_length,
     chaikin_smooth_keep_topology,
@@ -52,6 +54,7 @@ from geogenalg.core.geometry import (
     extract_interior_rings,
     extract_interior_rings_gdf,
     get_topological_points,
+    insert_vertex,
     largest_part,
     lines_to_segments,
     mean_z,
@@ -60,10 +63,12 @@ from geogenalg.core.geometry import (
     perforate_polygon_with_gdf_exteriors,
     point_on_line,
     polygon_rings_to_multilinestring,
+    ramer_douglas_peucker_simplify_keep_coords,
     remove_line_segments_at_wide_sections,
     remove_small_parts,
     scale_line_to_length,
     segment_direction,
+    snap_to_closest_vertex_or_segment,
     split_linear_geometry,
 )
 
@@ -2019,3 +2024,358 @@ def test_extend_line_by_raises():
             10,
             extend_from=LineExtendFrom.START,
         )
+
+
+@pytest.mark.parametrize(
+    ("geom", "vertex", "index", "expected"),
+    [
+        (
+            LineString([[0, 0], [1, 0]]),
+            Point(0.5, 0),
+            1,
+            LineString([[0, 0], [0.5, 0], [1, 0]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0]]),
+            Point(2.0, 0),
+            2,
+            LineString([[0, 0], [1, 0], [2, 0]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0], [1, 1], [2, 3]]),
+            Point(1.75, 3),
+            3,
+            LineString([[0, 0], [1, 0], [1, 1], [1.75, 3], [2, 3]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0]]),
+            Point(0.5, 0, 5),
+            1,
+            LineString([[0, 0], [0.5, 0], [1, 0]]),
+        ),
+        (
+            LineString([[0, 0, 1], [1, 0, 2]]),
+            Point(0.5, 0, 5),
+            1,
+            LineString([[0, 0, 1], [0.5, 0, 5], [1, 0, 2]]),
+        ),
+        (
+            LineString([[0, 0, 1], [1, 0, 2]]),
+            Point(0.5, 0),
+            1,
+            LineString([[0, 0, 1], [0.5, 0, 0], [1, 0, 2]]),
+        ),
+    ],
+    ids=[
+        "one_segment",
+        "at_end",
+        "multiple_segments",
+        "vertex_has_z_line_does_not",
+        "vertex_has_z_so_does_line",
+        "line_has_z_vertex_does_not",
+    ],
+)
+def test_insert_vertex(
+    geom: LineString,
+    vertex: Point,
+    index: int,
+    expected: LineString,
+):
+    assert insert_vertex(geom, vertex, index) == expected
+
+
+@pytest.mark.parametrize(
+    ("geom", "point", "expected"),
+    [
+        (
+            LineString([[0, 0], [1, 0]]),
+            Point(0.50, 0),
+            LineString([[0, 0], [0.5, 0], [1, 0]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0], [2, 0]]),
+            Point(0.50, 0),
+            LineString([[0, 0], [0.5, 0], [1, 0], [2, 0]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0], [2, 0]]),
+            Point(1.5, 0),
+            LineString([[0, 0], [1, 0], [1.5, 0], [2, 0]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0], [2, 0], [2, 1], [2, 2]]),
+            Point(2.0, 0.5),
+            LineString([[0, 0], [1, 0], [2, 0], [2.0, 0.5], [2, 1], [2, 2]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0], [2, 0], [2, 1], [2, 2]]),
+            Point(2.0, 1.25),
+            LineString([[0, 0], [1, 0], [2, 0], [2, 1], [2.0, 1.25], [2, 2]]),
+        ),
+        (
+            LineString([[2, 2], [2, 1], [2, 0], [1, 0], [0, 0]]),
+            Point(2.0, 1.25),
+            LineString([[2, 2], [2.0, 1.25], [2, 1], [2, 0], [1, 0], [0, 0]]),
+        ),
+        (
+            LineString([[1, 0], [0, 0]]),
+            Point(0.50, 0),
+            LineString([[1, 0], [0.5, 0], [0, 0]]),
+        ),
+        (
+            LineString([[1, 0], [0, 0]]),
+            Point(0.20, 0),
+            LineString([[1, 0], [0.2, 0], [0, 0]]),
+        ),
+        (
+            LineString([[1, 0], [0, 0]]),
+            Point(0.20, 0, 5),
+            LineString([[1, 0], [0.2, 0], [0, 0]]),
+        ),
+        (
+            LineString([[1, 0, 1], [0, 0, 1]]),
+            Point(0.20, 0, 5),
+            LineString([[1, 0, 1], [0.2, 0, 5], [0, 0, 1]]),
+        ),
+        (
+            LineString([[1, 0], [0, 0]]),
+            Point(1, 0),
+            LineString([[1, 0], [0, 0]]),
+        ),
+        (
+            LineString([[1, 0], [0, 0]]),
+            Point(5, 5),
+            LineString([[1, 0], [0, 0]]),
+        ),
+    ],
+    ids=[
+        "one_segment",
+        "two_segments_add_to_first",
+        "two_segments_add_to_second",
+        "four_segments_add_to_third",
+        "four_segments_add_to_last",
+        "four_segments_add_to_last_reversed",
+        "one_segment_reversed",
+        "one_segment_reversed_not_exactly_in_middle",
+        "z_in_point_not_in_geom",
+        "z_in_point_and_in_geom",
+        "at_vertex",
+        "not_within",
+    ],
+)
+def test_add_topological_point(
+    geom: LineString,
+    point: Point,
+    expected: LineString,
+):
+    assert add_topological_point(geom, point) == expected
+
+
+@pytest.mark.parametrize(
+    ("geom", "points", "expected"),
+    [
+        (
+            LineString([[0, 0], [1, 0]]),
+            [Point(0.50, 0)],
+            LineString([[0, 0], [0.5, 0], [1, 0]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0]]),
+            [Point(0.50, 0), Point(0.1234, 0)],
+            LineString([[0, 0], [0.1234, 0], [0.5, 0], [1, 0]]),
+        ),
+        (
+            LineString([[2, 2], [2, 1], [2, 0], [1, 0], [0, 0]]),
+            [Point(0.5, 0), Point(2, 1.26), Point(2, 2), Point(2, 1.789)],
+            LineString(
+                [
+                    [2, 2],
+                    [2.0, 1.789],
+                    [2, 1.26],
+                    [2, 1],
+                    [2, 0],
+                    [1, 0],
+                    [0.5, 0],
+                    [0, 0],
+                ]
+            ),
+        ),
+    ],
+    ids=[
+        "one_point",
+        "two_points",
+        "many_points_to_different_segments",
+    ],
+)
+def test_add_topological_points(
+    geom: LineString,
+    points: list[Point],
+    expected: LineString,
+):
+    assert add_topological_points(geom, points) == expected
+
+
+@pytest.mark.parametrize(
+    ("point", "snap_to", "tolerance", "z_behavior", "expected"),
+    [
+        (Point(0, 0.01), LineString([[0, 0], [1, 0]]), 0, "inherit", Point(0, 0)),
+        (Point(0, 2), LineString([[0, 0], [1, 0]]), 1, "inherit", Point(0, 0)),
+        (Point(0, 2), LineString([[0, 0], [1, 0]]), 3, "inherit", Point(0, 2)),
+        (Point(0, 0.01), box(0, 0, 1, -1), 0, "inherit", Point(0, 0)),
+        (Point(0, 0), Point(1, 1), 0, "inherit", Point(1, 1)),
+        (Point(0, 0, 5), Point(1, 1), 0, "inherit", Point(1, 1, 5)),
+        (Point(0, 0, 5), Point(1, 1), 0, "exclude", Point(1, 1)),
+    ],
+    ids=[
+        "snap_to_line",
+        "outside_tolerance",
+        "within_tolerance",
+        "snap_to_polygon",
+        "snap_to_point",
+        "z_inherit",
+        "z_exclude",
+    ],
+)
+def test_snap_to_closest_vertex_or_segment(
+    point: Point,
+    snap_to: BaseGeometry,
+    tolerance: float,
+    z_behavior: Literal["inherit", "exclude"],
+    expected: Point,
+):
+    assert (
+        snap_to_closest_vertex_or_segment(
+            point,
+            snap_to,
+            tolerance,
+            z_behavior,
+        )
+        == expected
+    )
+
+
+def test_add_topological_point_raises():
+    with pytest.raises(ValueError, match=r"Tolerance should be 0 or above."):
+        add_topological_point(
+            Point(),
+            Point(),
+            -1,
+        )
+
+
+def test_add_topological_points_raises():
+    with pytest.raises(ValueError, match=r"Tolerance should be 0 or above."):
+        add_topological_points(
+            Point(),
+            Point(),
+            -1,
+        )
+
+
+@pytest.mark.parametrize(
+    ("geom", "tolerance", "keep_cords", "expected"),
+    [
+        (
+            LineString(
+                [
+                    [0, 0],
+                    [5, 0],
+                    [10, 2],
+                    [15, 0],
+                    [20, 4],
+                    [25, 8],
+                    [20, 10],
+                    [20, 15],
+                    [24, 20],
+                ]
+            ),
+            2,
+            set(),
+            LineString(
+                [
+                    [0, 0],
+                    [15, 0],
+                    [25, 8],
+                    [20, 10],
+                    [24, 20],
+                ]
+            ),
+        ),
+        (
+            LineString(
+                [
+                    [0, 0],
+                    [5, 0],
+                    [10, 2],
+                    [15, 0],
+                    [20, 4],
+                    [25, 8],
+                    [20, 10],
+                    [20, 15],
+                    [24, 20],
+                ]
+            ),
+            2,
+            {Point(-5, -5)},
+            LineString(
+                [
+                    [0, 0],
+                    [15, 0],
+                    [25, 8],
+                    [20, 10],
+                    [24, 20],
+                ]
+            ),
+        ),
+        (
+            LineString(
+                [
+                    [0, 0],
+                    [5, 0],
+                    [10, 2],
+                    [15, 0],
+                    [20, 4],
+                    [25, 8],
+                    [20, 10],
+                    [20, 15],
+                    [24, 20],
+                ]
+            ),
+            2,
+            {
+                Point(5, 0),
+                Point(10, 2),
+            },
+            LineString(
+                [
+                    [0, 0],
+                    [5, 0],
+                    [10, 2],
+                    [15, 0],
+                    [25, 8],
+                    [20, 10],
+                    [24, 20],
+                ]
+            ),
+        ),
+    ],
+    ids=[
+        "no_keep_cords",
+        "keep_cord_not_in_line",
+        "has_keep_coords",
+    ],
+)
+def test_ramer_douglas_peucker_simplify_keep_coords(
+    geom: LineString,
+    tolerance: float,
+    keep_cords: set[Point],
+    expected: LineString,
+):
+    assert (
+        ramer_douglas_peucker_simplify_keep_coords(
+            geom,
+            tolerance,
+            keep_cords,
+        )
+        == expected
+    )

--- a/test/core/test_geometry.py
+++ b/test/core/test_geometry.py
@@ -68,6 +68,8 @@ from geogenalg.core.geometry import (
     remove_small_parts,
     scale_line_to_length,
     segment_direction,
+    smooth_around_connection_point_of_two_lines,
+    smooth_around_ring_closing_vertex,
     snap_to_closest_vertex_or_segment,
     split_linear_geometry,
 )
@@ -2379,3 +2381,214 @@ def test_ramer_douglas_peucker_simplify_keep_coords(
         )
         == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("line", "spline_subdivisions", "expected"),
+    [
+        (
+            LineString([[0, 0], [1, 0]]),
+            10,
+            LineString([[0, 0], [1, 0]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0], [0.5, 1], [0.5, -1]]),
+            10,
+            LineString([[0, 0], [1, 0], [0.5, 1], [0.5, -1]]),
+        ),
+        (
+            LineString(),
+            10,
+            LineString(),
+        ),
+        (
+            LineString([[0, 0], [1, 1], [3, 1], [2, 0], [0, 0]]),
+            2,
+            LineString(
+                [
+                    [0, 0],
+                    [0.3079449839416705, 0.5000000000000001],
+                    [1, 1],
+                    [3, 1],
+                    [2, 0],
+                    [0.8385016254650557, -0.161498374534944],
+                    [0, 0],
+                ]
+            ),
+        ),
+    ],
+    ids=[
+        "not_closed",
+        "not_valid",
+        "empty",
+        "ring",
+    ],
+)
+def test_smooth_around_ring_closing_vertex(
+    line: LineString,
+    spline_subdivisions: int,
+    expected: LineString,
+):
+    assert equals_exact(
+        smooth_around_ring_closing_vertex(
+            line, spline_subdivisions=spline_subdivisions
+        ),
+        expected,
+        tolerance=0.000000001,
+    )
+
+
+@pytest.mark.parametrize(
+    ("line_1", "line_2", "point", "spline_subdivisions", "expected_1", "expected_2"),
+    [
+        (
+            LineString(),
+            LineString(),
+            Point(),
+            10,
+            LineString(),
+            LineString(),
+        ),
+        (
+            LineString([[0, 0], [1, 0]]),
+            LineString([[5, 5], [6, 5]]),
+            Point(0, 0),
+            10,
+            LineString([[0, 0], [1, 0]]),
+            LineString([[5, 5], [6, 5]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0]]),
+            LineString([[1, 0], [1, 1]]),
+            Point(5, 5),
+            10,
+            LineString([[0, 0], [1, 0]]),
+            LineString([[1, 0], [1, 1]]),
+        ),
+        (
+            LineString([[0, 0], [1, 0]]),
+            LineString([[1, 0], [1, 1]]),
+            Point(0, 0),
+            10,
+            LineString([[0, 0], [1, 0]]),
+            LineString([[1, 0], [1, 1]]),
+        ),
+        (
+            LineString(
+                [
+                    [0, 0],
+                    [1.25, 0.25],
+                    [1.75, 1],
+                    [2.5, 2],
+                    [4, 3],
+                ]
+            ),
+            LineString(
+                [
+                    [4, 3],
+                    [5, 2],
+                    [6, 4.25],
+                    [5.5, 4.75],
+                    [5, 6],
+                ]
+            ),
+            Point(4, 3),
+            3,
+            LineString(
+                [
+                    [0, 0],
+                    [1.25, 0.25],
+                    [1.75, 1],
+                    [2.5, 2],
+                    [2.9661258867648237, 2.433208736292763],
+                    [3.5049204064058337, 2.842054416166005],
+                    [4, 3],
+                ]
+            ),
+            LineString(
+                [
+                    [4, 3],
+                    [4.363927764355153, 2.711489274491867],
+                    [4.693562719333668, 2.2261563204196673],
+                    [5, 2],
+                    [6, 4.25],
+                    [5.5, 4.75],
+                    [5, 6],
+                ]
+            ),
+        ),
+        (
+            LineString(
+                [
+                    [0, 0],
+                    [1.25, 0.25],
+                    [1.75, 1],
+                    [2.5, 2],
+                    [4, 3],
+                ]
+            ),
+            LineString(
+                [
+                    [4, 3],
+                    [5, 2],
+                    [6, 4.25],
+                    [5.5, 4.75],
+                    [5, 6],
+                    [0, 6],
+                    [-2, 3],
+                    [0, 0],
+                ]
+            ),
+            Point(4, 3),
+            3,
+            LineString(
+                [
+                    [0, 0],
+                    [1.25, 0.25],
+                    [1.75, 1],
+                    [2.5, 2],
+                    [2.9661258867648237, 2.433208736292763],
+                    [3.5049204064058337, 2.842054416166005],
+                    [4, 3],
+                ]
+            ),
+            LineString(
+                [
+                    [4, 3],
+                    [4.363927764355153, 2.711489274491867],
+                    [4.693562719333668, 2.2261563204196673],
+                    [5, 2],
+                    [6, 4.25],
+                    [5.5, 4.75],
+                    [5, 6],
+                    [0, 6],
+                    [-2, 3],
+                    [0, 0],
+                ]
+            ),
+        ),
+    ],
+    ids=[
+        "empty_1",
+        "lines_disjoint",
+        "point_disjoint",
+        "point_disjoint_other",
+        "should_smooth",
+        "makes_ring",
+    ],
+)
+def test_smooth_around_connection_point_of_two_lines(
+    line_1: LineString,
+    line_2: LineString,
+    point: Point,
+    spline_subdivisions: int,
+    expected_1: LineString,
+    expected_2: LineString,
+):
+    result_1, result_2 = smooth_around_connection_point_of_two_lines(
+        line_1, line_2, point, spline_subdivisions=spline_subdivisions
+    )
+
+    assert equals_exact(result_1, expected_1, tolerance=0.000000001)
+
+    assert equals_exact(result_2, expected_2, tolerance=0.000000001)

--- a/test/core/test_geometry.py
+++ b/test/core/test_geometry.py
@@ -2065,7 +2065,19 @@ def test_extend_line_by_raises():
             LineString([[0, 0, 1], [1, 0, 2]]),
             Point(0.5, 0),
             1,
-            LineString([[0, 0, 1], [0.5, 0, 0], [1, 0, 2]]),
+            LineString([[0, 0, 1], [0.5, 0, 1.5], [1, 0, 2]]),
+        ),
+        (
+            LineString([[0, 0, 1], [1, 0, 2]]),
+            Point(0.5, 0),
+            0,
+            LineString([[0.5, 0, 1], [0, 0, 1], [1, 0, 2]]),
+        ),
+        (
+            LineString([[0, 0, 1], [1, 0, 2]]),
+            Point(1, 1),
+            2,
+            LineString([[0, 0, 1], [1, 0, 2], [1, 1, 2]]),
         ),
     ],
     ids=[
@@ -2075,6 +2087,8 @@ def test_extend_line_by_raises():
         "vertex_has_z_line_does_not",
         "vertex_has_z_so_does_line",
         "line_has_z_vertex_does_not",
+        "line_has_z_vertex_does_not_start",
+        "line_has_z_vertex_does_not_end",
     ],
 )
 def test_insert_vertex(

--- a/test/test_continuity.py
+++ b/test/test_continuity.py
@@ -29,7 +29,7 @@ from geogenalg.continuity import (
     get_segments_in_polygon_exteriors_but_not_in_lines,
     inspect_dead_end_candidates,
     process_lines_and_reconnect,
-    smooth_contiguously,
+    smooth_linestring_connections,
 )
 
 
@@ -1663,13 +1663,13 @@ def test_get_segments_in_polygon_exteriors_but_not_in_lines(
 @pytest.mark.parametrize(
     (
         "input_gdf",
-        "iterations",
+        "spline_subdivisions",
         "expected_gdf",
     ),
     [
         (
             GeoDataFrame(geometry=[]),
-            5,
+            10,
             GeoDataFrame(geometry=[]),
         ),
         (
@@ -1677,40 +1677,104 @@ def test_get_segments_in_polygon_exteriors_but_not_in_lines(
                 {"attribute": ["1", "2"]},
                 index=[1, 2],
                 geometry=[
-                    LineString([[0, 0], [1, 1]]),
-                    LineString([[1, 1], [2, 0]]),
+                    LineString(
+                        [
+                            [0, 0],
+                            [1.25, 0.25],
+                            [1.75, 1],
+                            [2.5, 2],
+                            [4, 3],
+                        ]
+                    ),
+                    LineString(
+                        [
+                            [4, 3],
+                            [5, 2],
+                            [6, 4.25],
+                            [5.5, 4.75],
+                            [5, 6],
+                        ]
+                    ),
                 ],
             ),
-            1,
+            3,
             GeoDataFrame(
                 {"attribute": ["1", "2"]},
                 index=[1, 2],
                 geometry=[
-                    LineString([[0, 0], [0.75, 0.75], [1, 0.75]]),
-                    LineString([[1, 0.75], [1.25, 0.75], [2, 0]]),
+                    LineString(
+                        [
+                            [0, 0],
+                            [1.25, 0.25],
+                            [1.75, 1],
+                            [2.5, 2],
+                            [2.9661258867648237, 2.433208736292763],
+                            [3.5049204064058337, 2.842054416166005],
+                            [4, 3],
+                        ]
+                    ),
+                    LineString(
+                        [
+                            [4, 3],
+                            [4.363927764355153, 2.711489274491867],
+                            [4.693562719333668, 2.2261563204196673],
+                            [5, 2],
+                            [6, 4.25],
+                            [5.5, 4.75],
+                            [5, 6],
+                        ]
+                    ),
                 ],
             ),
         ),
         (
             GeoDataFrame(
-                {"attribute": ["1", "2", "3", "4"]},
-                index=[1, 2, 3, 4],
+                {"attribute": ["1"]},
+                index=[1],
                 geometry=[
-                    LineString([[0, 0], [1, 1]]),
-                    LineString([[1, 1], [2, 0]]),
-                    LineString([[2, 0], [1, -1]]),
-                    LineString([[1, -1], [0, 0]]),
+                    LineString(
+                        [
+                            [0, 0],
+                            [1.25, 0.25],
+                            [1.75, 1],
+                            [2.5, 2],
+                            [4, 3],
+                            [5, 2],
+                            [6, 4.25],
+                            [5.5, 4.75],
+                            [5, 6],
+                            [0, 6],
+                            [-2, 3],
+                            [0, 0],
+                        ]
+                    ),
                 ],
             ),
-            1,
+            3,
             GeoDataFrame(
-                {"attribute": ["1", "2", "3", "4"]},
-                index=[1, 2, 3, 4],
+                {"attribute": ["1"]},
+                index=[1],
                 geometry=[
-                    LineString([[0.25, 0], [0.25, 0.25], [0.75, 0.75], [1, 0.75]]),
-                    LineString([[1, 0.75], [1.25, 0.75], [1.75, 0.25], [1.75, 0]]),
-                    LineString([[1.75, 0], [1.75, -0.25], [1.25, -0.75], [1, -0.75]]),
-                    LineString([[1, -0.75], [0.75, -0.75], [0.25, -0.25], [0.25, 0]]),
+                    LineString(
+                        [
+                            [0, 0],
+                            [0.4396802056781041, -0.0548478681379274],
+                            [0.884397910840029, 0.0588325415544701],
+                            [1.25, 0.25],
+                            [1.75, 1],
+                            [2.5, 2],
+                            [4, 3],
+                            [5, 2],
+                            [6, 4.25],
+                            [5.5, 4.75],
+                            [5, 6],
+                            [0, 6],
+                            [-2, 3],
+                            [-1.6343790296899408, 1.8411100158993157],
+                            [-0.8243136149354368, 0.6822200317986311],
+                            [0, 0],
+                        ]
+                    ),
                 ],
             ),
         ),
@@ -1721,17 +1785,18 @@ def test_get_segments_in_polygon_exteriors_but_not_in_lines(
         "ring",
     ],
 )
-def test_smooth_contiguously(
+def test_smooth_linestring_connections(
     input_gdf: GeoDataFrame,
-    iterations: int,
+    spline_subdivisions: int,
     expected_gdf: GeoDataFrame,
 ):
-    result = smooth_contiguously(
+    result = smooth_linestring_connections(
         input_gdf,
-        iterations=iterations,
+        spline_subdivisions=spline_subdivisions,
     )
     assert_geodataframe_equal(
         result,
         expected_gdf,
         check_like=True,
+        check_less_precise=True,
     )

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -59,8 +59,11 @@ loc
 multilinestring
 multipolygon
 nodata
+peucker
 polygonize
 pygeoops
+ramer
+rdp
 rect
 rglob
 segmentize

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -11,6 +11,7 @@ bbox
 boffet
 bools
 cartagen
+catmull
 centerline
 centroid
 centroids
@@ -78,6 +79,7 @@ splitters
 sqrt
 stacklevel
 starmap
+subdivs
 testdata
 tolist
 topo


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Add various geometry functions aiming to support smoothing of lines in such a way that line endpoints don't form harsh angles (without moving the end points themselves).

Before/after (red: non-smoothed, purple: smoothed version):
<img width="845" height="754" alt="kuva" src="https://github.com/user-attachments/assets/1c149440-635d-4093-a12e-bee8fcbb0f1e" />

Some functions are added to support the upcoming contour line algorithm:
* `add_topological_point(s)`, `snap_to_closest_vertex_or_segment`
  * allow adding a vertex matching closest slope point
  * these will likely have other uses as well
* `ramer_douglas_peucker_simplify_keep_coords` one option to modify contour geometries while not shifting away from slope point

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

- [ ] Non-breaking change
- [x] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
