### PR TITLE
test: test algorithms with dummy data, fix revealed issues

### DIFF
--- a/src/geogenalg/application/__init__.py
+++ b/src/geogenalg/application/__init__.py
@@ -5,13 +5,18 @@
 #  SPDX-License-Identifier: MIT
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from pathlib import Path
 from typing import ClassVar, TypeVar, final
 
 from geopandas import GeoDataFrame, read_file
 from pandas.api.types import is_string_dtype
 
-from geogenalg.core.exceptions import GeometryTypeError, InvalidCRSError
+from geogenalg.core.exceptions import (
+    GeometryTypeError,
+    InvalidCRSError,
+    MissingReferenceError,
+)
 from geogenalg.utility.hash import reset_with_random_hash_index
 from geogenalg.utility.validation import (
     ShapelyGeometryTypeString,
@@ -21,15 +26,22 @@ from geogenalg.utility.validation import (
 _SUPPORTS_IDENTITY_ATTR = "__supports_identity"
 
 
+@dataclass(frozen=True)
+class ReferenceDataInformation:
+    """Struct for defining information about reference data an algorithm accepts."""
+
+    valid_geometry_types: set[ShapelyGeometryTypeString]
+    required: bool
+
+
 class BaseAlgorithm(ABC):
     """Abstract base class for all algorithms."""
 
     valid_input_geometry_types: ClassVar[set[ShapelyGeometryTypeString]] = set()
     """Set of accepted geometry types for input data. If there is a mismatch,
     GeometryTypeError will be raised."""
-    valid_reference_geometry_types: ClassVar[set[ShapelyGeometryTypeString]] = set()
-    """Set of accepted geometry types for reference data. If there is a mismatch,
-    GeometryTypeError will be raised."""
+    reference_data_schema: ClassVar[dict[str, ReferenceDataInformation]] = {}
+    """Dictionary telling what kind of reference data algorithm accepts."""
     requires_projected_crs: ClassVar[bool] = True
     """Tells whether algorithm requires a projected coordinate reference
     system. If True, when data with non-projected CRS is passed to execute(),
@@ -134,6 +146,7 @@ class BaseAlgorithm(ABC):
                 subclass.
             InvalidCRSError: If input or reference data has missing, non-projected
                 or differing coordinate reference systems.
+            MissingReferenceError: If a required reference dataset is missing.
 
         """
         if not self.valid_input_geometry_types:
@@ -159,18 +172,28 @@ class BaseAlgorithm(ABC):
             msg = "Algorithm requires projected CRS and data does not have one."
             raise InvalidCRSError(msg)
 
-        for key, reference in reference_data.items():
+        for key_attribute, ref in self.reference_data_schema.items():
+            key = getattr(self, key_attribute)
+            reference = reference_data.get(key)
+
+            if reference is None and ref.required:
+                raise MissingReferenceError
+
+            if reference is None:
+                continue
+
             if not check_gdf_geometry_type(
                 reference,
-                self.valid_reference_geometry_types,
+                ref.valid_geometry_types,
             ):
                 types = (
-                    next(iter(self.valid_reference_geometry_types))
-                    if len(self.valid_reference_geometry_types) == 1
-                    else f"{', '.join(sorted(self.valid_reference_geometry_types))}"
+                    next(iter(ref.valid_geometry_types))
+                    if len(ref.valid_geometry_types) == 1
+                    else f"{', '.join(sorted(ref.valid_geometry_types))}"
                 )
                 msg = (
-                    "Reference data must contain only geometries of following types: "
+                    f'Reference data "{key}" must contain only '
+                    + "geometries of following types: "
                     + f"{types}."
                 )
                 raise GeometryTypeError(msg)

--- a/src/geogenalg/application/generalize_building_areas.py
+++ b/src/geogenalg/application/generalize_building_areas.py
@@ -9,7 +9,11 @@ from typing import ClassVar, override
 
 from geopandas.geodataframe import GeoDataFrame
 
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.application.generalize_building_areas_by_geometry import (
     GeneralizeBuildingAreasByGeometry,
 )
@@ -17,7 +21,6 @@ from geogenalg.application.generalize_building_areas_by_parcel import (
     GeneralizeBuildingAreasByParcel,
 )
 from geogenalg.application.generalize_landcover import GeneralizeLandcover
-from geogenalg.core.exceptions import MissingReferenceError
 from geogenalg.core.geometry import assign_nearest_z
 from geogenalg.identity import hash_index_from_geometry
 from geogenalg.utility.dataframe_processing import combine_gdfs
@@ -97,7 +100,20 @@ class GeneralizeBuildingAreas(BaseAlgorithm):
     """Reference data key for parcel data."""
 
     valid_input_geometry_types: ClassVar = {"Polygon"}
-    valid_reference_geometry_types: ClassVar = {"Polygon", "LineString"}
+    reference_data_schema: ClassVar = {
+        "reference_key_parcels": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "Polygon",
+            },
+        ),
+        "reference_key_roads": ReferenceDataInformation(
+            required=False,
+            valid_geometry_types={
+                "LineString",
+            },
+        ),
+    }
 
     @override
     def _execute(
@@ -105,9 +121,6 @@ class GeneralizeBuildingAreas(BaseAlgorithm):
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        if self.reference_key_parcels not in reference_data:
-            raise MissingReferenceError
-
         reference_roads = (
             reference_data[self.reference_key_roads]
             if self.reference_key_roads in reference_data
@@ -158,6 +171,11 @@ class GeneralizeBuildingAreas(BaseAlgorithm):
             # or far from other areas
             area_threshold=0.0,
         ).execute(gdf)
+
+        if gdf.empty:
+            # GeneralizeLandCover may have eroded all areas away, which
+            # will cause overlay() to fail later -> return early
+            return gdf
 
         # Remove sections from building areas which are too close to the
         # reference roads

--- a/src/geogenalg/application/generalize_building_areas_by_geometry.py
+++ b/src/geogenalg/application/generalize_building_areas_by_geometry.py
@@ -10,7 +10,10 @@ from cartagen.enrichment.urban.urban_areas import boffet_areas
 from geopandas import GeoDataFrame
 from geopandas.geoseries import GeoSeries
 
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    supports_identity,
+)
 from geogenalg.core.geometry import assign_nearest_z
 from geogenalg.identity import hash_index_from_geometry
 
@@ -35,7 +38,6 @@ class GeneralizeBuildingAreasByGeometry(BaseAlgorithm):
     buildings located on the edge."""
 
     valid_input_geometry_types: ClassVar = {"Polygon"}
-    valid_reference_geometry_types: ClassVar = {"LineString"}
 
     @override
     def _execute(

--- a/src/geogenalg/application/generalize_building_areas_by_parcel.py
+++ b/src/geogenalg/application/generalize_building_areas_by_parcel.py
@@ -10,8 +10,11 @@ from typing import ClassVar, override
 from geopandas import GeoDataFrame
 
 from geogenalg.analyze import calculate_coverage
-from geogenalg.application import BaseAlgorithm, supports_identity
-from geogenalg.core.exceptions import MissingReferenceError
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.core.geometry import assign_nearest_z
 from geogenalg.identity import hash_index_from_geometry
 from geogenalg.merge import buffer_and_merge_polygons
@@ -50,7 +53,14 @@ class GeneralizeBuildingAreasByParcel(BaseAlgorithm):
     """Reference data key for parcel data."""
 
     valid_input_geometry_types: ClassVar = {"Polygon"}
-    valid_reference_geometry_types: ClassVar = {"Polygon"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "Polygon",
+            },
+        ),
+    }
 
     @override
     def _execute(
@@ -58,9 +68,6 @@ class GeneralizeBuildingAreasByParcel(BaseAlgorithm):
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        if self.reference_key not in reference_data:
-            raise MissingReferenceError
-
         building_coverage_column = "__coverage"
         result_gdf = data.copy()
         parcels_gdf = reference_data[self.reference_key]

--- a/src/geogenalg/application/generalize_cliffs.py
+++ b/src/geogenalg/application/generalize_cliffs.py
@@ -8,8 +8,11 @@ from typing import ClassVar, override
 
 from geopandas import GeoDataFrame
 
-from geogenalg.application import BaseAlgorithm, supports_identity
-from geogenalg.core.exceptions import MissingReferenceError
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.selection import remove_close_line_segments, remove_short_lines
 from geogenalg.split import explode_and_hash_id
 
@@ -37,7 +40,15 @@ class GeneralizeCliffs(BaseAlgorithm):
     """Reference data key for roads data."""
 
     valid_input_geometry_types: ClassVar = {"LineString", "MultiLineString"}
-    valid_reference_geometry_types: ClassVar = {"LineString", "MultiLineString"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "LineString",
+                "MultiLineString",
+            },
+        ),
+    }
     required_projected_crs: ClassVar = False
 
     @override
@@ -46,23 +57,7 @@ class GeneralizeCliffs(BaseAlgorithm):
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        """Execute algorithm.
-
-        Raises:
-            GeometryTypeError: If input GeoDataFrames have incorrect geometry types.
-            MissingReferenceError: If reference data is not found.
-
-        Returns:
-            Generalized cliff lines.
-
-        Raises:
-            MissingReferenceError: If reference data is missing.
-
-        """
-        if self.reference_key in reference_data:
-            roads_data = reference_data[self.reference_key]
-        else:
-            raise MissingReferenceError
+        roads_data = reference_data[self.reference_key]
 
         result = remove_close_line_segments(data, roads_data, self.buffer_size)
         result = remove_short_lines(result, self.length_threshold)

--- a/src/geogenalg/application/generalize_conservation_areas.py
+++ b/src/geogenalg/application/generalize_conservation_areas.py
@@ -10,11 +10,15 @@ from typing import ClassVar
 from geopandas import GeoDataFrame
 
 from geogenalg.analyze import calculate_edge_adjacency
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.application.generalize_landcover import GeneralizeLandcover
 from geogenalg.identity import hash_index_from_old_ids
 from geogenalg.merge import dissolve_and_inherit_attributes
-from geogenalg.utility.dataframe_processing import combine_gdfs, combine_geoseries
+from geogenalg.utility.dataframe_processing import combine_gdfs
 
 WATER_PROXIMITY_DISTANCE = 20
 WATER_RATIO_THRESHOLD = 0.5
@@ -58,9 +62,19 @@ class GeneralizeConservationAreas(BaseAlgorithm):
     """If True, polygons will be smoothed."""
     group_by: frozenset[str] = frozenset()
     """Column(s) whose values define the groups to be dissolved."""
+    reference_key: str = "water_areas"
+    """Reference data key for water area data."""
 
-    valid_input_geometry_types: ClassVar = {"Polygon", "MultiPolygon"}
-    valid_reference_geometry_types: ClassVar = {"Polygon", "MultiPolygon"}
+    valid_input_geometry_types: ClassVar = {"Polygon"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "Polygon",
+                "MultiPolygon",
+            },
+        ),
+    }
 
     def _execute(
         self,
@@ -69,12 +83,7 @@ class GeneralizeConservationAreas(BaseAlgorithm):
     ) -> GeoDataFrame:
         gdf = data.copy()
 
-        # Merge reference layers from the dictionary into a single GeoDataFrame
-        reference_geoms = [gdf.geometry for gdf in reference_data.values()]
-        combined_series = combine_geoseries(reference_geoms, ignore_index=True)
-        reference_gdf = GeoDataFrame(geometry=combined_series)
-        reference_gdf = reference_gdf.explode(index_parts=False).reset_index(drop=True)
-        reference_gdf = reference_gdf[~reference_gdf.geometry.is_empty]
+        reference_gdf = reference_data[self.reference_key]
 
         # Compute water adjacency ratio for each conservation area
         gdf = calculate_edge_adjacency(

--- a/src/geogenalg/application/generalize_fences.py
+++ b/src/geogenalg/application/generalize_fences.py
@@ -8,12 +8,14 @@ from dataclasses import dataclass
 from hashlib import sha256
 from typing import ClassVar, override
 
-from cartagen.utils.partitioning.network import network_faces
 from geopandas import GeoDataFrame
 
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.continuity import connect_nearby_endpoints
-from geogenalg.core.exceptions import MissingReferenceError
 from geogenalg.core.geometry import assign_nearest_z
 from geogenalg.merge import merge_connecting_lines_by_attribute
 from geogenalg.selection import (
@@ -62,7 +64,14 @@ class GeneralizeFences(BaseAlgorithm):
     """Reference data key to use as a source of mast data."""
 
     valid_input_geometry_types: ClassVar = {"LineString"}
-    valid_reference_geometry_types: ClassVar = {"Point"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "Point",
+            },
+        ),
+    }
 
     @override
     def _execute(
@@ -70,26 +79,6 @@ class GeneralizeFences(BaseAlgorithm):
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        """Execute algorithm.
-
-        Args:
-        ----
-            data: A GeoDataFrame containing the fence lines to be generalized.
-            reference_data: Should contain a Point GeoDataFrame.
-
-        Returns:
-        -------
-            GeoDataFrame containing the generalized fence lines.
-
-        Raises:
-        ------
-            MissingReferenceError: If reference data is missing.
-            KeyError: If specified attribute for merging lines is not specified.
-
-        """
-        if self.reference_key not in reference_data:
-            raise MissingReferenceError
-
         if self.attribute_for_line_merge not in data.columns:
             msg = (
                 "Specified `attribute_for_line_merge` "
@@ -123,8 +112,8 @@ class GeneralizeFences(BaseAlgorithm):
         # Combine original fence lines with helper lines
         combined_gdf = combine_gdfs([result_gdf, helper_lines_gdf], ignore_index=True)
 
-        # Calculate the CartaGen network faces to fill closing line geometries
-        faces = network_faces(list(combined_gdf.geometry), convex_hull=False)
+        # Calculate the network faces to fill closing line geometries
+        faces = combined_gdf.geometry.polygonize()
         faces_gdf = GeoDataFrame(geometry=list(faces))
 
         # Dissolve adjacent polygons into larger contiguous areas

--- a/src/geogenalg/application/generalize_points.py
+++ b/src/geogenalg/application/generalize_points.py
@@ -61,7 +61,7 @@ class GeneralizePoints(BaseAlgorithm):
     an unchanged point."""
 
     valid_input_geometry_types: ClassVar = {"Point"}
-    required_projected_crs: ClassVar = False
+    requires_projected_crs: ClassVar = False
 
     def _execute(
         self,

--- a/src/geogenalg/application/generalize_power_lines.py
+++ b/src/geogenalg/application/generalize_power_lines.py
@@ -12,14 +12,17 @@ from pygeoops import centerline
 from shapely.geometry import Polygon
 
 from geogenalg.analyze import get_polygons_for_parallel_lines
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.attributes import inherit_attributes_from_largest
 from geogenalg.continuity import (
     connect_lines_to_polygon_centroids,
     flag_polygon_centerline_connections,
     process_lines_and_reconnect,
 )
-from geogenalg.core.exceptions import MissingReferenceError
 from geogenalg.core.geometry import (
     LineExtendFrom,
     assign_nearest_z,
@@ -67,7 +70,20 @@ class GeneralizePowerLines(BaseAlgorithm):
     """Reference key for substation dataset."""
 
     valid_input_geometry_types: ClassVar = {"LineString"}
-    valid_reference_geometry_types: ClassVar = {"LineString", "Polygon"}
+    reference_data_schema: ClassVar = {
+        "reference_key_fences": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "LineString",
+            },
+        ),
+        "reference_key_substations": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "Polygon",
+            },
+        ),
+    }
 
     @override
     def _execute(
@@ -75,12 +91,6 @@ class GeneralizePowerLines(BaseAlgorithm):
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        if self.reference_key_fences not in reference_data:
-            raise MissingReferenceError
-
-        if self.reference_key_substations not in reference_data:
-            raise MissingReferenceError
-
         fences = reference_data[self.reference_key_fences]
         substations = reference_data[self.reference_key_substations]
 

--- a/src/geogenalg/application/generalize_roads.py
+++ b/src/geogenalg/application/generalize_roads.py
@@ -8,7 +8,11 @@ from typing import ClassVar, override
 
 from geopandas import GeoDataFrame
 
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.continuity import add_contiguous_lines_information
 
 
@@ -33,7 +37,14 @@ class GeneralizeRoads(BaseAlgorithm):
     """Reference key for other line datasets which are part of the same network."""
 
     valid_input_geometry_types: ClassVar = {"LineString"}
-    valid_reference_geometry_types: ClassVar = {"LineString"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=False,
+            valid_geometry_types={
+                "LineString",
+            },
+        ),
+    }
 
     @override
     def _execute(

--- a/src/geogenalg/application/generalize_shared_paths.py
+++ b/src/geogenalg/application/generalize_shared_paths.py
@@ -9,12 +9,15 @@ from typing import ClassVar
 
 from geopandas import GeoDataFrame
 
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.continuity import (
     get_lines_along_reference_lines,
     process_lines_and_reconnect,
 )
-from geogenalg.core.exceptions import MissingReferenceError
 from geogenalg.core.geometry import (
     assign_nearest_z,
 )
@@ -44,29 +47,21 @@ class GeneralizeSharedPaths(BaseAlgorithm):
     """Reference data, higher priority layer"""
 
     valid_input_geometry_types: ClassVar = {"LineString"}
-    valid_reference_geometry_types: ClassVar = {"LineString"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "LineString",
+            },
+        ),
+    }
 
     def _execute(
         self,
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        """Execute algorithm.
-
-        Raises
-        ------
-            MissingReferenceError: if no reference data is provided
-
-        Returns
-        -------
-        GeoDataFrame of LineStrings that are not contained within
-        the detection_distance threshold around reference data LineStrings.
-
-        """
-        if self.reference_key in reference_data:
-            reference_gdf = reference_data[self.reference_key]
-        else:
-            raise MissingReferenceError
+        reference_gdf = reference_data[self.reference_key]
 
         def _process(geodataframe: GeoDataFrame) -> GeoDataFrame:
             return get_lines_along_reference_lines(

--- a/src/geogenalg/application/generalize_shoreline.py
+++ b/src/geogenalg/application/generalize_shoreline.py
@@ -10,8 +10,11 @@ from typing import ClassVar, override
 
 from geopandas import GeoDataFrame, overlay
 
-from geogenalg.application import BaseAlgorithm, supports_identity
-from geogenalg.core.exceptions import MissingReferenceError
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.split import explode_and_hash_id
 
 logger = logging.getLogger(__name__)
@@ -38,7 +41,15 @@ class GeneralizeShoreline(BaseAlgorithm):
     "Reference data key to use as the source of the generalized shoreline."
 
     valid_input_geometry_types: ClassVar = {"LineString"}
-    valid_reference_geometry_types: ClassVar = {"Polygon", "MultiPolygon"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "Polygon",
+                "MultiPolygon",
+            },
+        ),
+    }
 
     @override
     def _execute(
@@ -46,19 +57,7 @@ class GeneralizeShoreline(BaseAlgorithm):
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        """Execute algorithm.
-
-        Raises:
-            MissingReferenceError: If reference data is not found.
-
-        Returns:
-            New shoreline extracted from generalized water areas.
-
-        """
-        if self.reference_key in reference_data:
-            water_areas_gdf = reference_data[self.reference_key]
-        else:
-            raise MissingReferenceError
+        water_areas_gdf = reference_data[self.reference_key]
 
         new_shoreline = water_areas_gdf.geometry.boundary.to_frame()
         new_shoreline = new_shoreline.explode()

--- a/src/geogenalg/application/generalize_water_areas.py
+++ b/src/geogenalg/application/generalize_water_areas.py
@@ -9,7 +9,11 @@ from typing import ClassVar, override
 from geopandas import GeoDataFrame, GeoSeries
 from shapely import MultiPoint, Polygon, force_2d
 
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.continuity import get_segments_in_polygon_exteriors_but_not_in_lines
 from geogenalg.core.exceptions import GeometryOperationError
 from geogenalg.core.geometry import (
@@ -72,7 +76,14 @@ class GeneralizeWaterAreas(BaseAlgorithm):
     non-shoreline vertices."""
 
     valid_input_geometry_types: ClassVar = {"Polygon"}
-    valid_reference_geometry_types: ClassVar = {"LineString"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=False,
+            valid_geometry_types={
+                "LineString",
+            },
+        ),
+    }
 
     @staticmethod
     def _get_skip_coords(data: GeoDataFrame, shoreline: GeoDataFrame) -> MultiPoint:
@@ -80,9 +91,6 @@ class GeneralizeWaterAreas(BaseAlgorithm):
 
         if segments.empty:
             return MultiPoint()
-
-        if segments.shape[0] == 1:
-            return MultiPoint(segments.union_all())
 
         points = segments.extract_unique_points().union_all()
 

--- a/src/geogenalg/application/generalize_watercourse_areas.py
+++ b/src/geogenalg/application/generalize_watercourse_areas.py
@@ -42,7 +42,6 @@ class GeneralizeWaterCourseAreas(GeneralizeWaterAreas):
     thin_section_exaggerate_by: float = 0.0
 
     valid_input_geometry_types: ClassVar = {"Polygon"}
-    valid_reference_geometry_types: ClassVar = {"LineString"}
 
     def _execute(
         self, data: GeoDataFrame, reference_data: dict[str, GeoDataFrame]

--- a/src/geogenalg/application/keep_intersection.py
+++ b/src/geogenalg/application/keep_intersection.py
@@ -8,8 +8,11 @@ from typing import ClassVar, override
 
 from geopandas import GeoDataFrame
 
-from geogenalg.application import BaseAlgorithm, supports_identity
-from geogenalg.core.exceptions import MissingReferenceError
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.split import explode_and_hash_id
 
 
@@ -40,9 +43,16 @@ class KeepIntersection(BaseAlgorithm):
         "Point",
         "MultiPoint",
         "LinearRing",
-        "GeometryCollection",
     }
-    valid_reference_geometry_types: ClassVar = {"Polygon", "MultiPolygon"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "Polygon",
+                "MultiPolygon",
+            },
+        ),
+    }
     requires_projected_crs: ClassVar = False
 
     @override
@@ -51,9 +61,6 @@ class KeepIntersection(BaseAlgorithm):
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        if self.reference_key not in reference_data:
-            raise MissingReferenceError
-
         mask_data = reference_data[self.reference_key]
 
         # Overlay does not keep index here, so copy it to a separate column,

--- a/src/geogenalg/application/remove_overlap.py
+++ b/src/geogenalg/application/remove_overlap.py
@@ -8,8 +8,11 @@ from typing import ClassVar, override
 
 from geopandas import GeoDataFrame
 
-from geogenalg.application import BaseAlgorithm, supports_identity
-from geogenalg.core.exceptions import MissingReferenceError
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.split import explode_and_hash_id
 
 
@@ -40,10 +43,17 @@ class RemoveOverlap(BaseAlgorithm):
         "Point",
         "MultiPoint",
         "LinearRing",
-        "GeometryCollection",
     }
 
-    valid_reference_geometry_types: ClassVar = {"Polygon", "MultiPolygon"}
+    reference_data_schema: ClassVar = {
+        "reference_key": ReferenceDataInformation(
+            required=True,
+            valid_geometry_types={
+                "Polygon",
+                "MultiPolygon",
+            },
+        )
+    }
     requires_projected_crs: ClassVar = False
 
     @override
@@ -52,9 +62,6 @@ class RemoveOverlap(BaseAlgorithm):
         data: GeoDataFrame,
         reference_data: dict[str, GeoDataFrame],
     ) -> GeoDataFrame:
-        if self.reference_key not in reference_data:
-            raise MissingReferenceError
-
         mask_data = reference_data[self.reference_key]
 
         # Overlay does not keep index here, so copy it to a separate column,

--- a/src/geogenalg/identity.py
+++ b/src/geogenalg/identity.py
@@ -129,7 +129,7 @@ def hash_index_from_old_ids(
     gdf.index = Index(new_index)
     gdf.index.name = data.index.name
 
-    if drop_old_ids:
+    if drop_old_ids and old_ids_column in gdf:
         gdf = gdf.drop(old_ids_column, axis=1)
 
     return gdf

--- a/src/geogenalg/merge.py
+++ b/src/geogenalg/merge.py
@@ -6,7 +6,6 @@
 from typing import Literal
 
 from geopandas import GeoDataFrame
-from pandas import Series
 from shapely import GeometryCollection, MultiPolygon, Polygon, line_merge
 from shapely.geometry import LineString, MultiLineString
 
@@ -209,9 +208,7 @@ def dissolve_and_inherit_attributes(
             features, geometry=input_gdf.geometry.name, crs=input_gdf.crs
         )
     else:
-        empty = copy_gdf_as_empty(input_gdf)
-        empty[old_ids_column] = Series(dtype="object")
-        return empty
+        return copy_gdf_as_empty(input_gdf, add_columns={old_ids_column: "object"})
 
     output.index.name = input_gdf.index.name
 

--- a/src/geogenalg/merge.py
+++ b/src/geogenalg/merge.py
@@ -6,12 +6,13 @@
 from typing import Literal
 
 from geopandas import GeoDataFrame
+from pandas import Series
 from shapely import GeometryCollection, MultiPolygon, Polygon, line_merge
 from shapely.geometry import LineString, MultiLineString
 
 from geogenalg.attributes import inherit_attributes
 from geogenalg.core.exceptions import GeometryTypeError
-from geogenalg.utility.dataframe_processing import combine_gdfs
+from geogenalg.utility.dataframe_processing import combine_gdfs, copy_gdf_as_empty
 from geogenalg.utility.validation import check_gdf_geometry_type
 
 
@@ -135,9 +136,6 @@ def dissolve_and_inherit_attributes(
         msg = "Dissolve only supports Polygon or MultiPolygon geometries."
         raise GeometryTypeError(msg)
 
-    if input_gdf.empty:
-        return input_gdf
-
     gdf = input_gdf.copy()
 
     # Apply buffer(0) to clean geometries. It fixes invalid polygons and
@@ -206,7 +204,15 @@ def dissolve_and_inherit_attributes(
 
         features.append(feature)
 
-    output = GeoDataFrame(features, geometry=input_gdf.geometry.name, crs=input_gdf.crs)
+    if features:
+        output = GeoDataFrame(
+            features, geometry=input_gdf.geometry.name, crs=input_gdf.crs
+        )
+    else:
+        empty = copy_gdf_as_empty(input_gdf)
+        empty[old_ids_column] = Series(dtype="object")
+        return empty
+
     output.index.name = input_gdf.index.name
 
     return output

--- a/src/geogenalg/selection.py
+++ b/src/geogenalg/selection.py
@@ -91,8 +91,8 @@ def split_polygons_by_point_intersection(
         lambda poly: point_gdf.geometry.intersects(poly).any()
     )
 
-    polygons_with_point: GeoDataFrame = polygon_gdf[polygons_intersecting_point]
-    polygons_without_point: GeoDataFrame = polygon_gdf[~polygons_intersecting_point]
+    polygons_with_point: GeoDataFrame = polygon_gdf.loc[polygons_intersecting_point]
+    polygons_without_point: GeoDataFrame = polygon_gdf.loc[~polygons_intersecting_point]
 
     return polygons_with_point, polygons_without_point
 

--- a/src/geogenalg/testing.py
+++ b/src/geogenalg/testing.py
@@ -13,12 +13,24 @@ from warnings import warn
 from geopandas import GeoDataFrame
 from geopandas.testing import assert_geodataframe_equal
 from pandas.testing import assert_series_equal
+from shapely.geometry import (
+    GeometryCollection,
+    LinearRing,
+    LineString,
+    MultiLineString,
+    MultiPoint,
+    MultiPolygon,
+    Point,
+    Polygon,
+)
+from shapely.geometry.base import BaseGeometry
 
 from geogenalg.application import BaseAlgorithm
 from geogenalg.utility.dataframe_processing import (
     combine_gdfs,
     read_gdf_from_file_and_set_index,
 )
+from geogenalg.utility.validation import ShapelyGeometryTypeString
 
 if TYPE_CHECKING:
     from pandas import DataFrame
@@ -304,3 +316,58 @@ def get_test_gdfs(  # noqa: PLR0913
         result,
         control,
     )
+
+
+def dummy_geometry(geom_type: ShapelyGeometryTypeString) -> BaseGeometry:  # noqa: PLR0911
+    """Give dummy geometry for testing purposes according to given type.
+
+    Returns
+    -------
+        Dummy geometry of given input geometry type.
+
+    """
+    match geom_type:
+        case "Point":
+            return Point(0, 0, 0)
+        case "LineString":
+            return LineString([[0, 0, 0], [1, 0, 0]])
+        case "LinearRing":
+            return LinearRing([[0, 0, 0], [1, 0, 0], [0, 1, 0], [0, 0, 0]])
+        case "Polygon":
+            return Polygon([[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 1, 0], [0, 0, 0]])
+        case "MultiPoint":
+            return MultiPoint([dummy_geometry("Point"), Point(1, 1, 0)])
+        case "MultiLineString":
+            return MultiLineString(
+                [
+                    dummy_geometry("LineString"),
+                    LineString([[0, 1, 0], [1, 1, 0]]),
+                ]
+            )
+        case "MultiPolygon":
+            return MultiPolygon(
+                [
+                    dummy_geometry("Polygon"),
+                    Polygon(
+                        [
+                            [10, 10, 0],
+                            [11, 10, 0],
+                            [11, 11, 0],
+                            [10, 11, 0],
+                            [10, 10, 0],
+                        ],
+                    ),
+                ]
+            )
+        case "GeometryCollection":
+            return GeometryCollection(
+                [
+                    dummy_geometry("Point"),
+                    dummy_geometry("LineString"),
+                    dummy_geometry("LinearRing"),
+                    dummy_geometry("Polygon"),
+                    dummy_geometry("MultiPoint"),
+                    dummy_geometry("MultiLineString"),
+                    dummy_geometry("MultiPolygon"),
+                ]
+            )

--- a/src/geogenalg/transform.py
+++ b/src/geogenalg/transform.py
@@ -3,11 +3,11 @@
 #  This file is part of geogen-algorithms.
 #
 #  SPDX-License-Identifier: MIT
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 from geopandas import GeoDataFrame, GeoSeries
-from numpy import nan
 from pygeoops import centerline
+from shapely import LineString, MultiLineString
 
 from geogenalg.attributes import inherit_attributes_from_largest
 from geogenalg.core.geometry import (
@@ -15,10 +15,7 @@ from geogenalg.core.geometry import (
     remove_line_segments_at_wide_sections,
     remove_small_parts,
 )
-from geogenalg.utility.dataframe_processing import copy_gdf_as_empty
-
-if TYPE_CHECKING:
-    from shapely import LineString, MultiLineString
+from geogenalg.utility.dataframe_processing import add_columns_to_gdf, copy_gdf_as_empty
 
 
 def thin_polygon_sections_to_lines(  # noqa: PLR0913
@@ -67,6 +64,15 @@ def thin_polygon_sections_to_lines(  # noqa: PLR0913
         ),
     )
 
+    if not isinstance(full_centerline, LineString | MultiLineString):
+        return copy_gdf_as_empty(
+            gdf,
+            add_columns={old_ids_column: "object"},
+        ), add_columns_to_gdf(
+            gdf,
+            {old_ids_column: "object"},
+        )
+
     lines = remove_line_segments_at_wide_sections(
         full_centerline.segmentize(width_check_distance),
         input_union,
@@ -76,10 +82,13 @@ def thin_polygon_sections_to_lines(  # noqa: PLR0913
     lines = remove_small_parts(lines, min_line_length)
 
     if lines.is_empty:
-        if old_ids_column is not None:
-            gdf[old_ids_column] = nan
-
-        return copy_gdf_as_empty(gdf), gdf
+        return copy_gdf_as_empty(
+            gdf,
+            add_columns={old_ids_column: "object"},
+        ), add_columns_to_gdf(
+            gdf,
+            {old_ids_column: "object"},
+        )
 
     # Create a polygonal mask from lines which have been determined to be long
     # enough. This is used to remove thin sections from the polygons.
@@ -125,7 +134,13 @@ def thin_polygon_sections_to_lines(  # noqa: PLR0913
         gdf[old_ids_column] = None
 
     if new_lines.is_empty:
-        return copy_gdf_as_empty(gdf), gdf
+        return copy_gdf_as_empty(
+            gdf,
+            add_columns={old_ids_column: "object"},
+        ), add_columns_to_gdf(
+            gdf,
+            {old_ids_column: "object"},
+        )
 
     new_lines = GeoSeries(new_lines).explode(ignore_index=True)
     new_line_features = GeoDataFrame(

--- a/src/geogenalg/utility/dataframe_processing.py
+++ b/src/geogenalg/utility/dataframe_processing.py
@@ -9,7 +9,7 @@ from typing import Literal, NotRequired, TypedDict, Unpack
 
 from geopandas import GeoDataFrame, read_file
 from geopandas.geoseries import GeoSeries
-from pandas import concat
+from pandas import Series, concat
 
 from geogenalg.core.exceptions import GeoCombineError
 
@@ -25,18 +25,65 @@ class ConcatParameters(TypedDict):
     copy: NotRequired[bool]
 
 
-def copy_gdf_as_empty(input_gdf: GeoDataFrame) -> GeoDataFrame:
+def copy_gdf_as_empty(
+    input_gdf: GeoDataFrame,
+    *,
+    add_columns: dict[str | None, str] | None = None,
+) -> GeoDataFrame:
     """Copy GeoDataFrame, retaining its structure (columns, crs) but not any rows.
 
-    Returns
+    Args:
+    ----
+        input_gdf: GeoDataFrame to copy.
+        add_columns: Optionally define new columns to add to copied GeoDataFrame.
+            Key is column name, value is column dtype. If key is None, it will
+            not be added.
+
+    Returns:
     -------
         GeoDataFrame with input_gdf's columns and crs but without any rows.
 
     """
+    if add_columns is None:
+        add_columns = {}
+
     # If input_gdf does not have an active geometry column, a DataFrame would
     # be returned. Wrap in gdf constructor to ensure a GeoDataFrame is always
     # returned.
-    return GeoDataFrame(input_gdf.iloc[0:0].copy())
+    gdf = GeoDataFrame(input_gdf.iloc[0:0].copy())
+    for name, dtype in add_columns.items():
+        if name is None:
+            continue
+
+        gdf[name] = Series(dtype=dtype)
+    return gdf
+
+
+def add_columns_to_gdf(
+    input_gdf: GeoDataFrame,
+    add_columns: dict[str | None, str],
+) -> GeoDataFrame:
+    """Add columns to a GeoDataFrame.
+
+    Args:
+    ----
+        input_gdf: GeoDataFrame to add to.
+        add_columns: New columns to add to GeoDataFrame. Key is column name,
+            value is column dtype. If key is None, the column will not be added.
+
+    Returns:
+    -------
+        GeoDataFrame with added columns.
+
+    """
+    gdf = input_gdf.copy()
+    for name, dtype in add_columns.items():
+        if name is None:
+            continue
+
+        gdf[name] = Series(dtype=dtype)
+
+    return gdf
 
 
 def _combine_geo_objects(

--- a/src/geogenalg/utility/dataframe_processing.py
+++ b/src/geogenalg/utility/dataframe_processing.py
@@ -76,8 +76,13 @@ def add_columns_to_gdf(
         GeoDataFrame with added columns.
 
     """
+    columns = {key: value for key, value in add_columns.items() if key is not None}
+
+    if not columns:
+        return input_gdf
+
     gdf = input_gdf.copy()
-    for name, dtype in add_columns.items():
+    for name, dtype in columns.items():
         if name is None:
             continue
 

--- a/test/application/test_base_algorithm.py
+++ b/test/application/test_base_algorithm.py
@@ -21,7 +21,11 @@ from shapely import (
     Polygon,
 )
 
-from geogenalg.application import BaseAlgorithm, supports_identity
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
 from geogenalg.core.exceptions import GeometryTypeError, InvalidCRSError
 
 
@@ -181,15 +185,22 @@ def test_wrong_geometry_type_input_data(input_data: GeoDataFrame):
 def test_wrong_geometry_type_reference_data(reference_data: GeoDataFrame):
     @supports_identity
     class MockAlg(BaseAlgorithm):
+        reference_key: str = "ref"
+
         valid_input_geometry_types: ClassVar = {"Point"}
-        valid_reference_geometry_types: ClassVar = {"Point"}
+        reference_data_schema: ClassVar = {
+            "reference_key": ReferenceDataInformation(
+                required=True,
+                valid_geometry_types={"Point"},
+            ),
+        }
 
         def _execute(self, data, reference_data):  # noqa: ANN001, ANN202, ARG002
             return data
 
     with pytest.raises(
         GeometryTypeError,
-        match=r"Reference data must contain only geometries of following types: Point.",
+        match=r'Reference data "ref" must contain only geometries of following types: Point.',
     ):
         MockAlg().execute(
             GeoDataFrame(geometry=[Point()], crs="EPSG:3857"), {"ref": reference_data}
@@ -262,6 +273,13 @@ def test_reference_invalid_crs(
 ):
     class MockAlg(BaseAlgorithm):
         valid_input_geometry_types: ClassVar = {"Point"}
+        reference_key: str = "ref"
+        reference_data_schema: ClassVar = {
+            "reference_key": ReferenceDataInformation(
+                required=True,
+                valid_geometry_types={"Point"},
+            ),
+        }
 
         def _execute(self, data, reference_data):  # noqa: ANN001, ANN202, ARG002
             return data

--- a/test/application/test_generalize_building_areas.py
+++ b/test/application/test_generalize_building_areas.py
@@ -43,4 +43,5 @@ def test_generalize_building_areas(testdata_path: Path) -> None:
             "roads": gpkg.to_input("roads"),
         },
         check_missing_reference=True,
+        dummy_data_mandatory_columns=["building_function_id"],
     ).run()

--- a/test/application/test_generalize_building_areas_by_parcel.py
+++ b/test/application/test_generalize_building_areas_by_parcel.py
@@ -34,4 +34,5 @@ def test_generalize_building_areas_by_parcel(testdata_path: Path) -> None:
             "parcels": gpkg.to_input("property_borders"),
         },
         check_missing_reference=True,
+        dummy_data_mandatory_columns=["kohdeluokka"],
     ).run()

--- a/test/application/test_generalize_buildings.py
+++ b/test/application/test_generalize_buildings.py
@@ -52,6 +52,7 @@ def test_generalize_buildings_50k(testdata_path: Path) -> None:
         ),
         unique_id_column=UNIQUE_ID_COLUMN,
         check_missing_reference=False,
+        dummy_data_mandatory_columns=["kayttotarkoitus"],
     ).run()
 
 
@@ -77,6 +78,7 @@ def test_generalize_buildings_100k(testdata_path: Path) -> None:
         ),
         unique_id_column=UNIQUE_ID_COLUMN,
         check_missing_reference=False,
+        dummy_data_mandatory_columns=["kayttotarkoitus"],
     ).run()
 
 
@@ -307,7 +309,7 @@ def test_filter_buildings_by_area_and_class_with_varied_geometries(
             GeoDataFrame(columns=["id", "class"], geometry=[]),
             "class",
             "id",
-            GeoDataFrame(columns=["id", "class"], geometry=[]),
+            GeoDataFrame(columns=["id", "class", "old_ids"], geometry=[]),
         ),
         (
             GeoDataFrame(

--- a/test/application/test_generalize_conservation_areas.py
+++ b/test/application/test_generalize_conservation_areas.py
@@ -34,10 +34,12 @@ def test_generalize_conservation_areas(
             hole_threshold=2000,
             smoothing=False,
             group_by=frozenset(["layer"]),
+            reference_key="water_areas",
         ),
         unique_id_column=UNIQUE_ID_COLUMN,
         reference_uris={
-            "water": gpkg.to_input("water_areas"),
+            "water_areas": gpkg.to_input("water_areas"),
         },
         check_missing_reference=False,
+        dummy_data_mandatory_columns=["layer"],
     ).run()

--- a/test/application/test_generalize_fences.py
+++ b/test/application/test_generalize_fences.py
@@ -34,4 +34,5 @@ def test_generalize_fences(testdata_path: Path) -> None:
         reference_uris={
             "masts": gpkg.to_input("masts"),
         },
+        dummy_data_mandatory_columns=["kohdeluokka"],
     ).run()

--- a/test/application/test_generalize_points.py
+++ b/test/application/test_generalize_points.py
@@ -83,4 +83,5 @@ def test_generalize_points(
         algorithm=algorithm,
         unique_id_column=UNIQUE_ID_COLUMN,
         check_missing_reference=False,
+        dummy_data_mandatory_columns=["boulder_in_water_type_id"],
     ).run()

--- a/test/application/test_generalize_power_lines.py
+++ b/test/application/test_generalize_power_lines.py
@@ -37,4 +37,5 @@ def test_generalize_power_lines(
             "fences": gpkg.to_input("fences"),
         },
         check_missing_reference=True,
+        dummy_data_mandatory_columns=["kohdeluokka"],
     ).run()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from tempfile import gettempdir
 from typing import Any
+from uuid import uuid4
 from warnings import warn
 
 import pytest
@@ -25,6 +26,7 @@ from geogenalg.testing import (
     TestGeoDataFrames,
     TestReportWarning,
     assert_gdf_equal_save_diff,
+    dummy_geometry,
     get_test_gdfs,
 )
 from geogenalg.utility.validation import geometry_string_to_type
@@ -67,6 +69,8 @@ class IntegrationTest:
         default_factory=dict
     )
     """Any arguments to pass to geopandas.testing.assert_geodataframe_equal."""
+    dummy_data_mandatory_columns: list[str] = field(default_factory=list)
+    """For defining columns which are required for algorithm to pass."""
 
     def get_test_gdfs(self, *, geometry_column: str | None = None) -> TestGeoDataFrames:
         """Get GeoDataFrames used in test.
@@ -145,6 +149,8 @@ class IntegrationTest:
     def run(self) -> None:
         """Run integration test."""
         algorithm_before = deepcopy(self.algorithm)
+
+        self._check_algorithm_passes_with_dummy_data()
         test_gdfs = self.get_test_gdfs()
 
         assert self.algorithm == algorithm_before
@@ -298,3 +304,36 @@ class IntegrationTest:
         if input_has_only_single_geometries and not result_has_only_single_geometries:
             msg = "Input has only single geometries but result does not."
             raise AssertionError(msg)
+
+    def _check_algorithm_passes_with_dummy_data(
+        self,
+    ) -> None:
+        attribute_data = {column: [1] for column in self.dummy_data_mandatory_columns}
+        attribute_data["field_1"] = [1]
+        data = GeoDataFrame(
+            attribute_data,
+            index=[str(uuid4())],
+            geometry=[
+                dummy_geometry(next(iter(self.algorithm.valid_input_geometry_types)))
+            ],
+            crs="EPSG:3857",
+        )
+
+        # TODO: selecting next from a set is non-deterministic potentially
+        # resulting in flaky tests?
+
+        reference_data = {}
+        for key, ref in self.algorithm.reference_data_schema.items():
+            reference_data[getattr(self.algorithm, key)] = GeoDataFrame(
+                {
+                    "field_1": [1],
+                },
+                index=[str(uuid4())],
+                geometry=[dummy_geometry(next(iter(ref.valid_geometry_types)))],
+                crs="EPSG:3857",
+            )
+
+        self.algorithm.execute(
+            data,
+            reference_data,
+        )

--- a/test/test_merge.py
+++ b/test/test_merge.py
@@ -21,6 +21,7 @@ from geogenalg.merge import (
     dissolve_polygon_layers,
     merge_connecting_lines_by_attribute,
 )
+from geogenalg.utility.dataframe_processing import add_columns_to_gdf
 
 
 @pytest.mark.parametrize(
@@ -410,6 +411,7 @@ def test_dissolve_and_inherit_attributes(
 def test_dissolve_and_inherit_attributes_handles_empty_gdf_correctly():
     input_gdf = GeoDataFrame(columns=["id", "group"], geometry=[])
     expected_gdf = GeoDataFrame(columns=["id", "group"], geometry=[])
+    expected_gdf = add_columns_to_gdf(expected_gdf, {"old_ids": "object"})
 
     result_gdf = dissolve_and_inherit_attributes(
         input_gdf,

--- a/test/test_transform.py
+++ b/test/test_transform.py
@@ -12,6 +12,7 @@ from numpy import nan
 from shapely import LineString, MultiPolygon, Polygon, box, union_all
 
 from geogenalg.transform import thin_polygon_sections_to_lines
+from geogenalg.utility.dataframe_processing import add_columns_to_gdf
 
 
 @pytest.mark.parametrize(
@@ -27,9 +28,12 @@ from geogenalg.transform import thin_polygon_sections_to_lines
                     box(0, 0, 100, 20),
                 ],
             ),
-            GeoDataFrame(
-                columns=["id", "attribute", "__old_ids"],
-                geometry=[],
+            add_columns_to_gdf(
+                GeoDataFrame(
+                    columns=["id", "attribute"],
+                    geometry=[],
+                ),
+                {"__old_ids": "object"},
             ),
             GeoDataFrame(
                 {
@@ -150,9 +154,6 @@ def test_thin_polygon_sections_to_lines(
     expected_polygons: GeoDataFrame,
     threshold: float,
 ):
-    if expected_lines.empty:
-        expected_lines["__old_ids"] = expected_lines["__old_ids"].astype("float64")
-
     input_gdf = input_gdf.set_index("id")
     modified_lines, modified_polygons = thin_polygon_sections_to_lines(
         input_gdf,

--- a/test/test_utility/test_dataframe_processing.py
+++ b/test/test_utility/test_dataframe_processing.py
@@ -18,6 +18,7 @@ from geogenalg.core.exceptions import GeoCombineError
 from geogenalg.utility import dataframe_processing
 from geogenalg.utility.dataframe_processing import (
     ConcatParameters,
+    add_columns_to_gdf,
     combine_gdfs,
     combine_geoseries,
     copy_gdf_as_empty,
@@ -526,3 +527,49 @@ def test_copy_gdf_as_empty_none_index_name():
     )
 
     assert result.index.name == input_gdf.index.name
+
+
+def test_add_columns_to_gdf():
+    gdf = GeoDataFrame({"field": [1, 2]})
+
+    result_1 = add_columns_to_gdf(gdf, add_columns={"new_field": "string"})
+    assert list(result_1["field"]) == [1, 2]
+    assert result_1["new_field"].dtype == "string"
+
+    result_2 = add_columns_to_gdf(gdf, add_columns={"new_field": "object"})
+    assert list(result_1["field"]) == [1, 2]
+    assert result_2["new_field"].dtype == "object"
+
+    result_3 = add_columns_to_gdf(
+        gdf, add_columns={"new_field_1": "object", "new_field_2": "float64"}
+    )
+    assert list(result_1["field"]) == [1, 2]
+    assert result_3["new_field_1"].dtype == "object"
+    assert result_3["new_field_2"].dtype == "float64"
+
+    result_4 = add_columns_to_gdf(gdf, add_columns={None: "object"})
+    assert list(result_1["field"]) == [1, 2]
+    assert result_4.columns == ["field"]
+
+
+def test_copy_gdf_as_empty_add_columns():
+    gdf = GeoDataFrame({"field": [1, 2]})
+
+    result_1 = copy_gdf_as_empty(gdf, add_columns={"new_field": "string"})
+    assert result_1.empty
+    assert result_1["new_field"].dtype == "string"
+
+    result_2 = copy_gdf_as_empty(gdf, add_columns={"new_field": "object"})
+    assert result_2.empty
+    assert result_2["new_field"].dtype == "object"
+
+    result_3 = copy_gdf_as_empty(
+        gdf, add_columns={"new_field_1": "object", "new_field_2": "float64"}
+    )
+    assert result_3.empty
+    assert result_3["new_field_1"].dtype == "object"
+    assert result_3["new_field_2"].dtype == "float64"
+
+    result_4 = copy_gdf_as_empty(gdf, add_columns={None: "object"})
+    assert result_4.empty
+    assert result_4.columns == ["field"]


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Make `IntegrationTest` run algorithm with generated dummy data to check if it passes.

To support this, change `BaseAlgorithm`'s `valid_reference_geometry_types` ClassVar to a dictionary describing each accepted reference data key attribute and whether it's required and what geometry types are accepted. This is something I've been thinking about doing anyway as the old system does not work very well for algorithms which accept or even require multiple types of reference data, because the geometry types were not actually correctly checked for each reference data gdf. This way we can also check missing reference data in `BaseAlgorithm` instead of every individual algorithm.

Fix issues revealed by running the dummy data checks.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
