### PR TITLE
fix(fences): ensure a list is always passed to gdf constructor

### DIFF
--- a/src/geogenalg/application/generalize_fences.py
+++ b/src/geogenalg/application/generalize_fences.py
@@ -9,6 +9,7 @@ from hashlib import sha256
 from typing import ClassVar, override
 
 from geopandas import GeoDataFrame
+from shapely.geometry.base import BaseMultipartGeometry
 
 from geogenalg.application import (
     BaseAlgorithm,
@@ -132,7 +133,11 @@ class GeneralizeFences(BaseAlgorithm):
         result_gdf = result_gdf.drop(index=to_remove_idx)
 
         # Convert MultiPolygon result back into a proper GeoDataFrame
-        polygons = list(faces_gdf.geoms)
+        if isinstance(faces_gdf, BaseMultipartGeometry):
+            polygons = list(faces_gdf.geoms)
+        else:
+            polygons = [faces_gdf]
+
         faces_gdf = GeoDataFrame(geometry=polygons, crs=data.crs)
 
         # Remove polygons whose area exceeds the closing_fence_area_with_mast_threshold


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Ensure a list is passed to GeoDataFrame constructor in case "faces" geometry is a single polygon.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
