### PR TITLE
fix: handle duplicate indexes in smooth_linestring_connections

### DIFF
--- a/src/geogenalg/continuity.py
+++ b/src/geogenalg/continuity.py
@@ -986,6 +986,11 @@ def smooth_linestring_connections(
         return copy_gdf_as_empty(input_gdf)
 
     gdf = input_gdf.copy()
+    old_index = gdf.index.copy()
+
+    # Reset index in case there's duplicate indices so we for sure have an
+    # unique index for assigning smoothed geometry
+    gdf = gdf.reset_index(drop=True)
 
     points = get_topological_points(input_gdf.geometry, force_2d=False)
 
@@ -1010,6 +1015,8 @@ def smooth_linestring_connections(
             geom, spline_subdivisions=spline_subdivisions
         )
     )
+
+    gdf.index = old_index
 
     return gdf
 

--- a/src/geogenalg/continuity.py
+++ b/src/geogenalg/continuity.py
@@ -986,7 +986,7 @@ def smooth_linestring_connections(
         return copy_gdf_as_empty(input_gdf)
 
     gdf = input_gdf.copy()
-    old_index = gdf.index.copy()
+    old_index = gdf.index
 
     # Reset index in case there's duplicate indices so we for sure have an
     # unique index for assigning smoothed geometry

--- a/test/test_continuity.py
+++ b/test/test_continuity.py
@@ -1779,11 +1779,67 @@ def test_get_segments_in_polygon_exteriors_but_not_in_lines(
                 ],
             ),
         ),
+        (
+            GeoDataFrame(
+                {"attribute": ["1", "2"]},
+                index=[1, 1],
+                geometry=[
+                    LineString(
+                        [
+                            [0, 0],
+                            [1.25, 0.25],
+                            [1.75, 1],
+                            [2.5, 2],
+                            [4, 3],
+                        ]
+                    ),
+                    LineString(
+                        [
+                            [4, 3],
+                            [5, 2],
+                            [6, 4.25],
+                            [5.5, 4.75],
+                            [5, 6],
+                        ]
+                    ),
+                ],
+            ),
+            3,
+            GeoDataFrame(
+                {"attribute": ["1", "2"]},
+                index=[1, 1],
+                geometry=[
+                    LineString(
+                        [
+                            [0, 0],
+                            [1.25, 0.25],
+                            [1.75, 1],
+                            [2.5, 2],
+                            [2.9661258867648237, 2.433208736292763],
+                            [3.5049204064058337, 2.842054416166005],
+                            [4, 3],
+                        ]
+                    ),
+                    LineString(
+                        [
+                            [4, 3],
+                            [4.363927764355153, 2.711489274491867],
+                            [4.693562719333668, 2.2261563204196673],
+                            [5, 2],
+                            [6, 4.25],
+                            [5.5, 4.75],
+                            [5, 6],
+                        ]
+                    ),
+                ],
+            ),
+        ),
     ],
     ids=[
         "empty",
         "non_ring",
         "ring",
+        "duplicate_index",
     ],
 )
 def test_smooth_linestring_connections(


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

`smooth_linestring_connections` assigns a modified geometry by index which fails in case there's duplicate indices. Fix by making index temporarily a range integer index.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
