### PR TITLE
fix(buildings): actually always keep buildings, and reduce them

### DIFF
--- a/src/geogenalg/application/generalize_buildings.py
+++ b/src/geogenalg/application/generalize_buildings.py
@@ -40,6 +40,7 @@ SIMPLIFY_EDGE_THRESHOLD_AFTER_NARROW_GAPS = 8
 NARROW_GAPS_THRESHOLD = 12
 BUFFER_SIZE_FOR_NARROW_PARTS = 3
 BUFFER_SIZE_FOR_NARROW_GAPS = 3.5
+POINT_SIZE_REDUCTION_MULTIPLIER = 1.66
 
 
 @supports_identity
@@ -238,14 +239,14 @@ class GeneralizeBuildings(BaseAlgorithm):
         other_buildings_gdf = reduce_nearby_points_by_selecting(
             other_buildings_gdf,
             all_buildings_gdf,
-            self.point_size * 1.66,
+            self.point_size * POINT_SIZE_REDUCTION_MULTIPLIER,
             self.original_area_column,
         )
 
         always_kept_buildings_gdf = reduce_nearby_points_by_selecting(
             always_kept_buildings_gdf,
             always_kept_buildings_gdf,
-            self.point_size * 1.66,
+            self.point_size * POINT_SIZE_REDUCTION_MULTIPLIER,
             self.original_area_column,
         )
 

--- a/src/geogenalg/application/generalize_buildings.py
+++ b/src/geogenalg/application/generalize_buildings.py
@@ -221,6 +221,12 @@ class GeneralizeBuildings(BaseAlgorithm):
             )
         ]
 
+        always_kept_buildings_gdf = point_buildings_gdf.loc[
+            point_buildings_gdf[self.building_class_column].isin(
+                self.classes_for_always_kept_buildings,
+            )
+        ]
+
         # Reduce density separately for each group
         low_priority_buildings_gdf = reduce_nearby_points_by_selecting(
             low_priority_buildings_gdf,
@@ -236,8 +242,19 @@ class GeneralizeBuildings(BaseAlgorithm):
             self.original_area_column,
         )
 
+        always_kept_buildings_gdf = reduce_nearby_points_by_selecting(
+            always_kept_buildings_gdf,
+            always_kept_buildings_gdf,
+            self.point_size * 1.66,
+            self.original_area_column,
+        )
+
         return combine_gdfs(
-            [low_priority_buildings_gdf, other_buildings_gdf],
+            [
+                low_priority_buildings_gdf,
+                other_buildings_gdf,
+                always_kept_buildings_gdf,
+            ],
         )
 
     def _generalize_polygon_buildings(

--- a/test/application/test_generalize_buildings.py
+++ b/test/application/test_generalize_buildings.py
@@ -14,7 +14,7 @@ from geopandas import GeoDataFrame
 from numpy import nan
 from pandas import isna
 from pandas.testing import assert_frame_equal
-from shapely import LineString, Point, Polygon
+from shapely import LineString, Point, Polygon, box
 from shapely.geometry.base import BaseGeometry
 
 from geogenalg.application.generalize_buildings import GeneralizeBuildings
@@ -22,6 +22,7 @@ from geogenalg.core.exceptions import GeometryTypeError
 from geogenalg.testing import (
     GeoPackagePath,
 )
+from geogenalg.utility.dataframe_processing import add_columns_to_gdf
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -401,3 +402,118 @@ def test_simplify_buildings_raises_on_invalid_geometry():
         ),
     ):
         GeneralizeBuildings._simplify_buildings(invalid_gdf, 5.0)
+
+
+@pytest.mark.parametrize(
+    (
+        "input_gdf",
+        "classes_for_low_priority_buildings",
+        "classes_for_always_kept_buildings",
+        "expected_gdf",
+    ),
+    [
+        (
+            GeoDataFrame({"class": []}, geometry=[]),
+            frozenset(),
+            frozenset(),
+            GeoDataFrame({"class": []}, geometry=[]),
+        ),
+        (
+            GeoDataFrame(
+                {"class": [1, 2], "original_area": [4, 5]},
+                geometry=[
+                    Point(0, 0),
+                    box(5, 5, 6, 6),
+                ],
+            ),
+            frozenset(),
+            frozenset([1]),
+            GeoDataFrame(
+                {"class": [1], "original_area": [4]},
+                geometry=[
+                    Point(0, 0),
+                ],
+            ),
+        ),
+        (
+            GeoDataFrame(
+                {"class": [1, 1, 2], "original_area": [5, 4, 5]},
+                geometry=[
+                    Point(0, 0),
+                    Point(0, 0.5),
+                    box(5, 5, 6, 6),
+                ],
+            ),
+            frozenset(),
+            frozenset([1]),
+            GeoDataFrame(
+                {"class": [1], "original_area": [5]},
+                geometry=[
+                    Point(0, 0),
+                ],
+            ),
+        ),
+        (
+            GeoDataFrame(
+                {"class": [5, 5], "original_area": [3.1, 4.1]},
+                geometry=[
+                    Point(0, 0),
+                    box(0.5, 0.5, 1.5, 1.5),
+                ],
+            ),
+            frozenset(),
+            frozenset(),
+            add_columns_to_gdf(
+                GeoDataFrame(
+                    geometry=[],
+                ),
+                {"class": "int64", "original_area": "float64"},
+            ),
+        ),
+        (
+            GeoDataFrame(
+                {"class": [4, 5], "original_area": [3.1, 4.1]},
+                geometry=[
+                    Point(0, 0),
+                    box(0.5, 0.5, 1.5, 1.5),
+                ],
+            ),
+            frozenset([4]),
+            frozenset(),
+            add_columns_to_gdf(
+                GeoDataFrame(
+                    geometry=[],
+                ),
+                {"class": "int64", "original_area": "float64"},
+            ),
+        ),
+    ],
+    ids=[
+        "empty",
+        "always_keep",
+        "always_keep_reduces",
+        "other_buildings",
+        "low_priority",
+    ],
+)
+def test_generalize_point_buildings(
+    input_gdf: GeoDataFrame,
+    classes_for_low_priority_buildings: frozenset[int | str],
+    classes_for_always_kept_buildings: frozenset[int | str],
+    expected_gdf: GeoDataFrame,
+):
+    centroids = input_gdf.loc[input_gdf.geometry.geom_type == "Polygon"].copy()
+    points = input_gdf.loc[input_gdf.geometry.geom_type == "Point"].copy()
+
+    centroids.geometry = centroids.geometry.centroid
+
+    result_gdf = GeneralizeBuildings(
+        classes_for_low_priority_buildings=classes_for_low_priority_buildings,
+        classes_for_always_kept_buildings=classes_for_always_kept_buildings,
+        building_class_column="class",
+    )._generalize_point_buildings(
+        points,
+        centroids,
+    )
+
+    assert_frame_equal(result_gdf, expected_gdf, check_like=True)


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Always kept buildings were not handled correctly in `_generalize_point_buildings`, all of them were entirely lost. Fix this, and add a step to reduce always kept buildings if they are too close to each other.

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Other

- [ ] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
