### PR TITLE
feat(landcover): remove cap style parameter

### DIFF
--- a/src/geogenalg/application/generalize_landcover.py
+++ b/src/geogenalg/application/generalize_landcover.py
@@ -51,8 +51,6 @@ class GeneralizeLandcover(BaseAlgorithm):
     """Minimum area of holes to retain."""
     smoothing: bool = False
     """If True, polygons will be smoothed."""
-    buffer_cap_style: Literal["round", "square", "flat"] = "square"
-    """Cap style used in buffer operations."""
     buffer_join_style: Literal["round", "mitre", "bevel"] = "bevel"
     """Join style used in buffer operations."""
     group_by: frozenset[str] = frozenset()
@@ -72,7 +70,6 @@ class GeneralizeLandcover(BaseAlgorithm):
         def _buffer(gdf: GeoDataFrame, distance: float) -> None:
             gdf.geometry = gdf.geometry.buffer(
                 distance,
-                cap_style=self.buffer_cap_style,
                 join_style=self.buffer_join_style,
             )
 


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Bit of a silly mistake, in https://github.com/nlsfi/geogen-algorithms/pull/94 `GeneralizeLandcover` got parameters for buffer join _and_ cap style. Problem is, the algorithm buffers only polygons for which the cap style makes absolutely no difference. Remove the cap style parameter to avoid confusion.


## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Other

- [ ] Non-breaking change
- [x] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
