### PR TITLE
feat(testing): add assert_geoseries_coordinates_equal

### DIFF
--- a/src/geogenalg/testing.py
+++ b/src/geogenalg/testing.py
@@ -11,8 +11,10 @@ from typing import TYPE_CHECKING, Any, Literal, NamedTuple, cast
 from warnings import warn
 
 from geopandas import GeoDataFrame
+from geopandas.geoseries import GeoSeries
 from geopandas.testing import assert_geodataframe_equal
-from pandas.testing import assert_series_equal
+from numpy import allclose
+from shapely import get_coordinates
 from shapely.geometry import (
     GeometryCollection,
     LinearRing,
@@ -93,6 +95,68 @@ class TestGeoDataFrames(NamedTuple):
     control: GeoDataFrame
 
 
+def assert_geoseries_coordinates_equal(
+    left: GeoSeries, right: GeoSeries, tolerance: float = 0.0
+) -> None:
+    """Assert that each matching geometry in two GeoSeries have the same coordinates.
+
+    The purpose of this function over geopandas.testing.assert_geoseries_equal is that
+    it also checks Z coordinates, not just X and Y.
+
+    Args:
+    ----
+        left: Other GeoSeries.
+        right: Other GeoSeries.
+        tolerance: Allowed difference between two coordinate values.
+
+    Raises:
+    ------
+        AssertionError: If coordinates don't match.
+
+    """
+
+    def _truncate_wkt(wkt: str) -> str:
+        if len(wkt) > 75:  # noqa: PLR2004
+            return wkt[0:75] + " ... "
+
+        return wkt
+
+    if len(left) != len(right):
+        msg = "GeoSeries are of different length."
+        raise AssertionError(msg)
+
+    length = len(left)
+    a = list(left)
+    b = list(right)
+
+    for i in range(length):
+        a_geom = a[i]
+        b_geom = b[i]
+
+        if type(a_geom) is not type(b_geom):
+            msg = (
+                "Geometries are not of equivalent type: "
+                + f"{type(a_geom).__name__} != {type(b_geom).__name__}"
+            )
+            raise AssertionError(msg)
+
+        a_coords = get_coordinates(a_geom, include_z=True)
+        b_coords = get_coordinates(b_geom, include_z=True)
+
+        if not allclose(
+            a_coords,
+            b_coords,
+            atol=tolerance,
+            rtol=0,
+            equal_nan=True,
+        ):
+            msg = (
+                "Geometries are not equivalent: "
+                + f"{_truncate_wkt(a_geom.wkt)} != {_truncate_wkt(b_geom.wkt)}"
+            )
+            raise AssertionError(msg)
+
+
 def assert_gdf_equal_save_diff(  # noqa: C901
     result: GeoDataFrame,
     control: GeoDataFrame,
@@ -130,9 +194,15 @@ def assert_gdf_equal_save_diff(  # noqa: C901
     try:
         assert_geodataframe_equal(result, control, **assert_function_arguments)
 
-        # Test GeoSeries separately, because assert_geodataframe_equal
+        # Test GeoSeries Zs separately, because assert_geodataframe_equal
         # does not check that Z values are equal.
-        assert_series_equal(result.geometry, control.geometry)
+        assert_geoseries_coordinates_equal(
+            result.geometry,
+            control.geometry,
+            tolerance=5e-07
+            if assert_function_arguments.get("check_less_precise")
+            else 0,
+        )
     except:
         if not directory.exists():
             directory.mkdir(parents=True)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,7 +16,6 @@ from warnings import warn
 import pytest
 from geopandas import GeoDataFrame
 from geopandas.testing import assert_geodataframe_equal
-from pandas.testing import assert_series_equal
 
 from geogenalg.application import BaseAlgorithm
 from geogenalg.core.exceptions import GeometryTypeError, MissingReferenceError
@@ -26,6 +25,7 @@ from geogenalg.testing import (
     TestGeoDataFrames,
     TestReportWarning,
     assert_gdf_equal_save_diff,
+    assert_geoseries_coordinates_equal,
     dummy_geometry,
     get_test_gdfs,
 )
@@ -180,9 +180,16 @@ class IntegrationTest:
                 test_gdfs.control,
                 **self.assert_function_arguments,
             )
-            # Test GeoSeries separately, because assert_geodataframe_equal
+
+            # Test GeoSeries Zs separately, because assert_geodataframe_equal
             # does not check that Z values are equal.
-            assert_series_equal(test_gdfs.result.geometry, test_gdfs.control.geometry)
+            assert_geoseries_coordinates_equal(
+                test_gdfs.result.geometry,
+                test_gdfs.control.geometry,
+                tolerance=5e-07
+                if self.assert_function_arguments.get("check_less_precise")
+                else 0,
+            )
         else:
             self._assert_and_save_report(test_gdfs.result, test_gdfs.control)
 

--- a/test/test_testing.py
+++ b/test/test_testing.py
@@ -3,6 +3,7 @@
 #  This file is part of geogen-algorithms.
 #
 #  SPDX-License-Identifier: MIT
+import re
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -11,14 +12,17 @@ from warnings import catch_warnings
 
 import pytest
 from geopandas import GeoDataFrame, read_file
+from geopandas.geoseries import GeoSeries
 from geopandas.testing import assert_geodataframe_equal
 from shapely import Point, Polygon, box
+from shapely.geometry import LineString, MultiLineString, MultiPolygon
 
 from geogenalg.application import BaseAlgorithm, supports_identity
 from geogenalg.testing import (
     GeoPackageInput,
     TestReportWarning,
     assert_gdf_equal_save_diff,
+    assert_geoseries_coordinates_equal,
     get_alg_results_from_geopackage,
     get_test_gdfs,
 )
@@ -395,3 +399,347 @@ def test_get_test_gdfs(
 
     for key, ref_gdf in other_ref.items():
         assert_geodataframe_equal(ref_gdf, ref_before[key])
+
+
+@pytest.mark.parametrize(
+    ("a", "b", "tolerance", "error_msg"),
+    [
+        (
+            GeoSeries(),
+            GeoSeries([Point(0, 0)]),
+            0,
+            "GeoSeries are of different length.",
+        ),
+        (
+            GeoSeries([box(0, 0, 1, 1)]),
+            GeoSeries([Point(0, 0)]),
+            0,
+            "Geometries are not of equivalent type: Polygon != Point",
+        ),
+        (
+            GeoSeries([Point(0, 0)]),
+            GeoSeries([Point(0, 0)]),
+            0,
+            None,
+        ),
+        (
+            GeoSeries([Point(0, 0.01)]),
+            GeoSeries([Point(0, 0)]),
+            0.1,
+            None,
+        ),
+        (
+            GeoSeries([Point(0, 0.1)]),
+            GeoSeries([Point(0, 0)]),
+            0.01,
+            "Geometries are not equivalent: POINT (0 0.1) != POINT (0 0)",
+        ),
+        (
+            GeoSeries([Point(0, 0, 1)]),
+            GeoSeries([Point(0, 0, 0)]),
+            0.1,
+            "Geometries are not equivalent: POINT Z (0 0 1) != POINT Z (0 0 0)",
+        ),
+        (
+            GeoSeries([Point(0, 0, 0)]),
+            GeoSeries([Point(0, 0, 0)]),
+            0,
+            None,
+        ),
+        (
+            GeoSeries([LineString([[0, 0, 0], [1, 0, 0]])]),
+            GeoSeries([LineString([[0, 0, 0], [1, 0, 0]])]),
+            0,
+            None,
+        ),
+        (
+            GeoSeries([LineString([[0, 0, 0], [1, 0, 0]])]),
+            GeoSeries([LineString([[0, 0, 0], [1, 0, 1]])]),
+            0,
+            "LINESTRING Z (0 0 0, 1 0 0) != LINESTRING Z (0 0 0, 1 0 1)",
+        ),
+        (
+            GeoSeries([LineString([[0, 0, 0.0000001], [1, 0, 0]])]),
+            GeoSeries([LineString([[0, 0, 0.000001], [1, 0, 0]])]),
+            0.000001,
+            None,
+        ),
+        (
+            GeoSeries(
+                [
+                    Polygon(
+                        [
+                            [0, 0, 0],
+                            [1, 0, 0],
+                            [1, 1, 0],
+                            [0, 1, 0],
+                        ]
+                    ),
+                ]
+            ),
+            GeoSeries(
+                [
+                    Polygon(
+                        [
+                            [0, 0, 0],
+                            [1, 0, 0],
+                            [1, 1, 0],
+                            [0, 1, 0.1],
+                        ]
+                    ),
+                ]
+            ),
+            0,
+            "Geometries are not equivalent: POLYGON Z ((0 0 0, 1 0 0, 1 1 0, 0 1 0, 0 0 0)) != POLYGON Z ((0 0 0, 1 0 0, 1 1 0, 0 1 0.1, 0 0 0))",
+        ),
+        (
+            GeoSeries(
+                [
+                    Polygon(
+                        [
+                            [0, 0, 0],
+                            [1, 0, 0],
+                            [1, 1, 0],
+                            [0, 1, 0],
+                        ]
+                    ),
+                ]
+            ),
+            GeoSeries(
+                [
+                    Polygon(
+                        [
+                            [0, 0, 0],
+                            [1, 0, 0],
+                            [1, 1, 0],
+                            [0, 1, 0.11],
+                        ]
+                    ),
+                ]
+            ),
+            0.1,
+            "Geometries are not equivalent: POLYGON Z ((0 0 0, 1 0 0, 1 1 0, 0 1 0, 0 0 0)) != POLYGON Z ((0 0 0, 1 0 0, 1 1 0, 0 1 0.11, 0 0 0))",
+        ),
+        (
+            GeoSeries(
+                [
+                    MultiPolygon(
+                        [
+                            Polygon(
+                                [
+                                    [0, 0, 0],
+                                    [1, 0, 0],
+                                    [1, 1, 0],
+                                    [0, 1, 0],
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    [5, 5, 5],
+                                    [6, 5, 5],
+                                    [6, 6, 5],
+                                    [5, 6, 5],
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            GeoSeries(
+                [
+                    MultiPolygon(
+                        [
+                            Polygon(
+                                [
+                                    [0, 0, 0],
+                                    [1, 0, 0],
+                                    [1, 1, 0],
+                                    [0, 1, 0],
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    [5, 5, 5],
+                                    [6, 5, 5],
+                                    [6, 6, 5],
+                                    [5, 6, 5],
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            0,
+            None,
+        ),
+        (
+            GeoSeries(
+                [
+                    MultiPolygon(
+                        [
+                            Polygon(
+                                [
+                                    [0, 0, 0.0001],
+                                    [1, 0, 0],
+                                    [1, 1, 0],
+                                    [0, 1, 0],
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    [5, 5, 5],
+                                    [6, 5, 5],
+                                    [6, 6, 5],
+                                    [5, 6, 5],
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            GeoSeries(
+                [
+                    MultiPolygon(
+                        [
+                            Polygon(
+                                [
+                                    [0, 0, 0],
+                                    [1, 0, 0],
+                                    [1, 1, 0],
+                                    [0, 1, 0],
+                                ]
+                            ),
+                            Polygon(
+                                [
+                                    [5, 5, 5],
+                                    [6, 5, 5],
+                                    [6, 6, 5],
+                                    [5, 6, 5],
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            0,
+            "Geometries are not equivalent: MULTIPOLYGON Z (((0 0 0.0001, 1 0 0, 1 1 0, 0 1 0, 0 0 0.0001)), ((5 5 5, 6 ...  != MULTIPOLYGON Z (((0 0 0, 1 0 0, 1 1 0, 0 1 0, 0 0 0)), ((5 5 5, 6 5 5, 6 6  ... ",
+        ),
+        (
+            GeoSeries(
+                [
+                    MultiLineString(
+                        [
+                            LineString(
+                                [
+                                    [0, 0, 0.0001],
+                                    [1, 1, 0],
+                                ]
+                            ),
+                            LineString(
+                                [
+                                    [5, 5, 0],
+                                    [7, 7, 0],
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            GeoSeries(
+                [
+                    MultiLineString(
+                        [
+                            LineString(
+                                [
+                                    [0, 0, 0],
+                                    [1, 1, 0],
+                                ]
+                            ),
+                            LineString(
+                                [
+                                    [5, 5, 0],
+                                    [7, 7, 0],
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            0,
+            "Geometries are not equivalent: MULTILINESTRING Z ((0 0 0.0001, 1 1 0), (5 5 0, 7 7 0)) != MULTILINESTRING Z ((0 0 0, 1 1 0), (5 5 0, 7 7 0))",
+        ),
+        (
+            GeoSeries(
+                [
+                    MultiLineString(
+                        [
+                            LineString(
+                                [
+                                    [0, 0, 0.0001],
+                                    [1, 1, 0],
+                                ]
+                            ),
+                            LineString(
+                                [
+                                    [5, 5, 0],
+                                    [7, 7, 0],
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            GeoSeries(
+                [
+                    MultiLineString(
+                        [
+                            LineString(
+                                [
+                                    [0, 0, 0],
+                                    [1, 1, 0],
+                                ]
+                            ),
+                            LineString(
+                                [
+                                    [5, 5, 0],
+                                    [7, 7, 0],
+                                ]
+                            ),
+                        ]
+                    ),
+                ]
+            ),
+            0.1,
+            None,
+        ),
+    ],
+    ids=[
+        "different_length",
+        "different_type",
+        "no_z_passes",
+        "no_z_passes_tolerance",
+        "no_z_does_not_pass_tolerance",
+        "z_unequal",
+        "z_equal",
+        "z_equal_line",
+        "z_unequal_line",
+        "z_equal_line_within_tolerance",
+        "polygon_not_equal",
+        "polygon_not_equal_tolerance",
+        "multipolygon_equals",
+        "multipolygon_not_equal",
+        "multilinestring_not_equal",
+        "multilinestring_equal",
+    ],
+)
+def test_assert_geoseries_z_values_match(
+    a: GeoSeries,
+    b: GeoSeries,
+    tolerance: int,
+    error_msg: str | None,
+):
+    if error_msg is not None:
+        with pytest.raises(AssertionError, match=re.escape(error_msg)):
+            assert_geoseries_coordinates_equal(a, b, tolerance)
+    else:
+        assert_geoseries_coordinates_equal(a, b, tolerance)

--- a/whitelist.txt
+++ b/whitelist.txt
@@ -2,10 +2,12 @@
 aggfunc
 alg
 algs
+allclose
 arctan2
 argmax
 argspec
 atan2
+atol
 basealgorithm
 basemetadata
 bbox
@@ -71,6 +73,7 @@ ramer
 rdp
 rect
 rglob
+rtol
 segmentize
 segmentized
 shapelysmooth


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

`assert_geoseries_equal` and `assert_geodataframe_equal` do not check if geometries have the same z coordinates. If you use the plain Pandas `assert_series_equal` it does check for z coordinates. This has been used so far, but this allows only exact checking so you can't enable `check_less_precise`.

This PR adds `[assert_geoseries_coordinates_equal](https://github.com/nlsfi/geogen-algorithms/pull/125/commits/ca7d499125a179c91cd1b81009a6a97b9f3497af)` which explicitly check that all coordinates including Z match in two GeoSeries.

This is required because in https://github.com/nlsfi/geogen-algorithms/pull/124 we get an issue where it looks like for some reason depending on the OS (Windows/Linux) you get slightly different coordinates on some vertices (on the millimiter or less scale), leading tests to fail on one OS or the other. This change allows to use the `check_less_precise` parameter to ignore miniscule differences like this.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
