### PR TITLE
Add tall building areas, fixes to building areas and main

### DIFF
--- a/src/geogenalg/application/generalize_building_areas.py
+++ b/src/geogenalg/application/generalize_building_areas.py
@@ -119,12 +119,15 @@ class GeneralizeBuildingAreas(BaseAlgorithm):
 
         copy = data.copy()
 
-        gdf = copy.loc[
-            ~(
-                (copy[self.building_filter_column].isin(self.classes_for_filtering))
-                & (copy.geometry.area > self.building_size_filter_threshold)
-            )
-        ]
+        if self.classes_for_filtering:
+            gdf = copy.loc[
+                ~(
+                    (copy[self.building_filter_column].isin(self.classes_for_filtering))
+                    & (copy.geometry.area > self.building_size_filter_threshold)
+                )
+            ]
+        else:
+            gdf = copy
 
         gdf.geometry = gdf.simplify(self.buildings_simplify_tolerance)
         gdf = GeoDataFrame(

--- a/src/geogenalg/application/generalize_tall_building_areas.py
+++ b/src/geogenalg/application/generalize_tall_building_areas.py
@@ -1,0 +1,49 @@
+#  Copyright (c) 2025 National Land Survey of Finland (Maanmittauslaitos)
+#
+#  This file is part of geogen-algorithms.
+#
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+from typing import ClassVar, override
+
+from geopandas import GeoDataFrame
+from pydantic import Field
+
+from geogenalg.application import (
+    BaseAlgorithm,
+    ReferenceDataInformation,
+    supports_identity,
+)
+
+from .generalize_building_areas import GeneralizeBuildingAreas
+
+
+@supports_identity
+class GeneralizeTallBuildingAreas(BaseAlgorithm):
+    """Generalize building areas, but only for multi-storey buildings."""
+
+    valid_input_geometry_types: ClassVar = {"Polygon"}
+
+    height_class_column: str = "building_height_class"
+    """Name of the column which defines building height classes."""
+
+    tall_building_classes: frozenset[int | str] = frozenset({2})
+    """Values in height_class_column that define tall buildings."""
+
+    @override
+    def _execute(
+        self,
+        data: GeoDataFrame,
+        reference_data: dict[str, GeoDataFrame] | None = None,
+    ) -> GeoDataFrame:
+
+        # Suodata korkeat rakennukset (täysin geneerinen)
+        filtered = data[data[self.height_class_column].isin(self.tall_building_classes)]
+
+        # Delegoi kaikki loppu pääalgoritmille
+        base_algo = GeneralizeBuildingAreas()
+
+        return base_algo.execute(
+            filtered,
+            reference_data=reference_data,
+        )

--- a/src/geogenalg/main.py
+++ b/src/geogenalg/main.py
@@ -46,6 +46,9 @@ from geogenalg.application.generalize_power_lines import GeneralizePowerLines
 from geogenalg.application.generalize_roads import GeneralizeRoads
 from geogenalg.application.generalize_shared_paths import GeneralizeSharedPaths
 from geogenalg.application.generalize_shoreline import GeneralizeShoreline
+from geogenalg.application.generalize_tall_building_areas import (
+    GeneralizeTallBuildingAreas,
+)
 from geogenalg.application.generalize_water_areas import GeneralizeWaterAreas
 from geogenalg.application.generalize_watercourse_areas import (
     GeneralizeWaterCourseAreas,
@@ -451,6 +454,7 @@ def build_app() -> None:
         "shared_paths": GeneralizeSharedPaths,
         "power_lines": GeneralizePowerLines,
         "building_areas": GeneralizeBuildingAreas,
+        "tall_building_areas": GeneralizeTallBuildingAreas,
         "dissolve_polygons": DissolvePolygons,
         "conservation_areas": GeneralizeConservationAreas,
     }


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Adds a new `tall-building-areas` algorithm that filters buildings by height class before delegating to the existing building areas workflow.

Also fixes `GeneralizeBuildingAreas` so it does not require `building_function_id` unless filtering is actually enabled, which avoids the KeyError when running the tall-building workflow with datasets that do not have that column.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [x] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md