### PR TITLE
Check columns in tests

### DIFF
--- a/src/geogenalg/application/generalize_building_areas.py
+++ b/src/geogenalg/application/generalize_building_areas.py
@@ -188,7 +188,7 @@ class GeneralizeBuildingAreas(BaseAlgorithm):
         if gdf.empty:
             # GeneralizeLandCover may have eroded all areas away, which
             # will cause overlay() to fail later -> return early
-            return gdf
+            return GeoDataFrame(geometry=[], crs=gdf.crs)
 
         # Remove sections from building areas which are too close to the
         # reference roads

--- a/src/geogenalg/application/generalize_railroads.py
+++ b/src/geogenalg/application/generalize_railroads.py
@@ -251,6 +251,10 @@ class GeneralizeRailroads(BaseAlgorithm):
         both_disconnected = (~tracks["_start_connected"]) & (~tracks["_end_connected"])
         tracks = tracks.loc[~(both_disconnected)]
 
+        tracks = tracks.drop(
+            [column for column in tracks.columns if column not in data.columns], axis=1
+        )
+
         tracks = tracks.set_index(tracks.index.astype("string"))
         tracks = inherit_attributes_from_largest(data, tracks)
         return hash_duplicate_indexes(tracks, "railroads")

--- a/src/geogenalg/application/generalize_water_areas.py
+++ b/src/geogenalg/application/generalize_water_areas.py
@@ -39,7 +39,7 @@ from geogenalg.exaggeration import (
     extract_narrow_polygon_parts,
 )
 from geogenalg.identity import hash_duplicate_indexes
-from geogenalg.utility.dataframe_processing import combine_gdfs
+from geogenalg.utility.dataframe_processing import combine_gdfs, copy_gdf_as_empty
 
 
 @supports_identity
@@ -387,6 +387,17 @@ class GeneralizeWaterAreas(BaseAlgorithm):
         # this by transforming any MultiPolygons to Polygons, retaining only
         # the largest part.
         gdf.geometry = gdf.geometry.apply(largest_part)
+
+        if gdf.empty:
+            return copy_gdf_as_empty(
+                gdf,
+                add_columns={
+                    str(name): str(dtype)
+                    for name, dtype in reference_data[self.reference_key].dtypes.items()
+                }
+                if self.reference_key in reference_data
+                else None,
+            )
 
         return self._post_process(
             gdf,

--- a/test/application/test_generalize_building_areas.py
+++ b/test/application/test_generalize_building_areas.py
@@ -5,7 +5,7 @@
 #  SPDX-License-Identifier: MIT
 from pathlib import Path
 
-from conftest import IntegrationTest
+from conftest import ExpectedResultColumns, IntegrationTest
 
 from geogenalg.application.generalize_building_areas import GeneralizeBuildingAreas
 from geogenalg.testing import GeoPackagePath
@@ -43,5 +43,8 @@ def test_generalize_building_areas(testdata_path: Path) -> None:
             "roads": gpkg.to_input("roads"),
         },
         check_missing_reference=False,
-        dummy_data_mandatory_columns=["building_function_id"],
+        dummy_data_mandatory_columns=frozenset(["building_function_id"]),
+        expected_result_columns=ExpectedResultColumns(
+            inherit="none",
+        ),
     ).run()

--- a/test/application/test_generalize_buildings.py
+++ b/test/application/test_generalize_buildings.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
-from conftest import IntegrationTest
+from conftest import ExpectedResultColumns, IntegrationTest
 from geopandas import GeoDataFrame
 from pandas import isna
 from pandas.testing import assert_frame_equal
@@ -51,7 +51,11 @@ def test_generalize_buildings_50k(testdata_path: Path) -> None:
         ),
         unique_id_column=UNIQUE_ID_COLUMN,
         check_missing_reference=False,
-        dummy_data_mandatory_columns=["kayttotarkoitus"],
+        dummy_data_mandatory_columns=frozenset(["kayttotarkoitus"]),
+        expected_result_columns=ExpectedResultColumns(
+            inherit="input",
+            acceptable_extra_colums=frozenset(["main_angle"]),
+        ),
     ).run()
 
 
@@ -76,7 +80,11 @@ def test_generalize_buildings_100k(testdata_path: Path) -> None:
         ),
         unique_id_column=UNIQUE_ID_COLUMN,
         check_missing_reference=False,
-        dummy_data_mandatory_columns=["kayttotarkoitus"],
+        dummy_data_mandatory_columns=frozenset(["kayttotarkoitus"]),
+        expected_result_columns=ExpectedResultColumns(
+            inherit="input",
+            acceptable_extra_colums=frozenset(["main_angle"]),
+        ),
     ).run()
 
 

--- a/test/application/test_generalize_conservation_areas.py
+++ b/test/application/test_generalize_conservation_areas.py
@@ -41,5 +41,5 @@ def test_generalize_conservation_areas(
             "water_areas": gpkg.to_input("water_areas"),
         },
         check_missing_reference=False,
-        dummy_data_mandatory_columns=["layer"],
+        dummy_data_mandatory_columns=frozenset(["layer"]),
     ).run()

--- a/test/application/test_generalize_contours.py
+++ b/test/application/test_generalize_contours.py
@@ -38,5 +38,5 @@ def test_generalize_contours(
         assert_function_arguments={
             "check_less_precise": True,
         },
-        dummy_data_mandatory_columns=["n60_elevation_value"],
+        dummy_data_mandatory_columns=frozenset(["n60_elevation_value"]),
     ).run()

--- a/test/application/test_generalize_fences.py
+++ b/test/application/test_generalize_fences.py
@@ -34,5 +34,5 @@ def test_generalize_fences(testdata_path: Path) -> None:
         reference_uris={
             "masts": gpkg.to_input("masts"),
         },
-        dummy_data_mandatory_columns=["kohdeluokka"],
+        dummy_data_mandatory_columns=frozenset(["kohdeluokka"]),
     ).run()

--- a/test/application/test_generalize_points.py
+++ b/test/application/test_generalize_points.py
@@ -7,7 +7,7 @@
 from pathlib import Path
 
 import pytest
-from conftest import IntegrationTest
+from conftest import ExpectedResultColumns, IntegrationTest
 
 from geogenalg.application.generalize_points import GeneralizePoints
 from geogenalg.testing import GeoPackagePath
@@ -83,5 +83,9 @@ def test_generalize_points(
         algorithm=algorithm,
         unique_id_column=UNIQUE_ID_COLUMN,
         check_missing_reference=False,
-        dummy_data_mandatory_columns=["boulder_in_water_type_id"],
+        dummy_data_mandatory_columns=frozenset(["boulder_in_water_type_id"]),
+        expected_result_columns=ExpectedResultColumns(
+            inherit="input",
+            acceptable_extra_colums=frozenset(["is_cluster"]),
+        ),
     ).run()

--- a/test/application/test_generalize_power_lines.py
+++ b/test/application/test_generalize_power_lines.py
@@ -37,5 +37,5 @@ def test_generalize_power_lines(
             "fences": gpkg.to_input("fences"),
         },
         check_missing_reference=True,
-        dummy_data_mandatory_columns=["kohdeluokka"],
+        dummy_data_mandatory_columns=frozenset(["kohdeluokka"]),
     ).run()

--- a/test/application/test_generalize_water_areas.py
+++ b/test/application/test_generalize_water_areas.py
@@ -7,7 +7,7 @@
 from pathlib import Path
 
 import pytest
-from conftest import IntegrationTest
+from conftest import ExpectedResultColumns, IntegrationTest
 from geopandas import GeoDataFrame
 from geopandas.testing import assert_geodataframe_equal
 from shapely import equals_exact
@@ -38,7 +38,6 @@ def test_generalize_water_areas(testdata_path: Path):
             island_simplification_tolerance=10.0,
             smoothing_passes=3,
             reference_key="shoreline",
-            include_new_shoreline=True,
             preserve_shoreline_sections_column="shoreline_type_id",
             preserve_shoreline_sections_values=frozenset([3]),
         ),
@@ -47,7 +46,12 @@ def test_generalize_water_areas(testdata_path: Path):
         },
         unique_id_column=UNIQUE_ID_COLUMN,
         check_missing_reference=False,
-        dummy_reference_data_mandatory_columns=["shoreline_type_id"],
+        dummy_reference_data_mandatory_columns=frozenset(["shoreline_type_id"]),
+        expected_result_columns=ExpectedResultColumns(
+            inherit="input",
+            inherit_from_reference_key="shoreline",
+            acceptable_extra_colums=frozenset(["feature_type"]),
+        ),
     ).run()
 
 

--- a/test/application/test_generalize_watercourse_areas.py
+++ b/test/application/test_generalize_watercourse_areas.py
@@ -6,7 +6,7 @@
 
 from pathlib import Path
 
-from conftest import IntegrationTest
+from conftest import ExpectedResultColumns, IntegrationTest
 
 from geogenalg.application.generalize_watercourse_areas import (
     GeneralizeWaterCourseAreas,
@@ -38,11 +38,16 @@ def test_generalize_watercourse_areas(testdata_path: Path):
             line_min_length=200.0,
             min_new_section_length=200.0,
             width_check_distance=10.0,
-            include_new_shoreline=True,
+            feature_type_column="feature_type",
         ),
         reference_uris={
             "shoreline": gpkg.to_input("shoreline"),
         },
         unique_id_column=UNIQUE_ID_COLUMN,
         check_missing_reference=False,
+        expected_result_columns=ExpectedResultColumns(
+            inherit="input",
+            inherit_from_reference_key="shoreline",
+            acceptable_extra_colums=frozenset(["feature_type"]),
+        ),
     ).run()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
 from tempfile import gettempdir
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 from warnings import warn
 
@@ -37,6 +37,15 @@ def testdata_path() -> Path:
     return Path(__file__).resolve().parent / "testdata"
 
 
+@dataclass(frozen=True)
+class ExpectedResultColumns:
+    """Class for defining expected columns in test result."""
+
+    inherit: Literal["input", "none"] = "input"
+    inherit_from_reference_key: str | None = None
+    acceptable_extra_colums: frozenset[str] = frozenset()
+
+
 GEOMETRY_TYPE_STRINGS = (
     "Point",
     "LineString",
@@ -47,6 +56,8 @@ GEOMETRY_TYPE_STRINGS = (
     "MultiPolygon",
     "GeometryCollection",
 )
+
+DEFAULT_EXPECTED_RESULT_COLUMNS = ExpectedResultColumns()
 
 
 @dataclass(frozen=True)
@@ -63,15 +74,17 @@ class IntegrationTest:
     """Name of column in input and reference data to set as GeoDataFrame index."""
     check_missing_reference: bool
     """If True, test will check that algorithm will raise a MissingReferenceError."""
+    expected_result_columns: ExpectedResultColumns = DEFAULT_EXPECTED_RESULT_COLUMNS
+    """Describes what columns result data should have."""
     reference_uris: dict[str, GeoPackageInput] = field(default_factory=dict)
     """Paths and layers of algorithm's reference data."""
     assert_function_arguments: dict[AssertFunctionParameter, Any] = field(
         default_factory=dict
     )
     """Any arguments to pass to geopandas.testing.assert_geodataframe_equal."""
-    dummy_data_mandatory_columns: list[str] = field(default_factory=list)
+    dummy_data_mandatory_columns: frozenset[str] = frozenset()
     """For defining columns which are required for algorithm to pass."""
-    dummy_reference_data_mandatory_columns: list[str] = field(default_factory=list)
+    dummy_reference_data_mandatory_columns: frozenset[str] = frozenset()
     """For defining columns for reference data which are required for algorithm
     to pass."""
 
@@ -163,6 +176,12 @@ class IntegrationTest:
         test_gdfs = self.get_test_gdfs()
 
         assert self.algorithm == algorithm_before
+
+        self._check_columns(
+            test_gdfs.input_data,
+            test_gdfs.reference_data,
+            test_gdfs.result,
+        )
 
         if any(test_gdfs.result.index.duplicated()):
             msg = "Duplicate indices found in result GeoDataFrame."
@@ -352,7 +371,7 @@ class IntegrationTest:
             reference_attributes = {
                 column: [1] for column in self.dummy_reference_data_mandatory_columns
             }
-            reference_attributes["field_1"] = [1]
+            reference_attributes["reference_field_1"] = [1]
             reference_data[getattr(self.algorithm, key)] = GeoDataFrame(
                 reference_attributes,
                 index=[str(uuid4())],
@@ -360,7 +379,52 @@ class IntegrationTest:
                 crs="EPSG:3857",
             )
 
-        self.algorithm.execute(
+        result = self.algorithm.execute(
             data,
             reference_data,
         )
+
+        self._check_columns(data, reference_data, result)
+
+    def _check_columns(
+        self,
+        input_data: GeoDataFrame,
+        reference_data: dict[str, GeoDataFrame],
+        result: GeoDataFrame,
+    ) -> None:
+        acceptable_extra_columns = self.expected_result_columns.acceptable_extra_colums
+        result_columns = set(result.columns)
+
+        match self.expected_result_columns.inherit:
+            case "input":
+                if self.expected_result_columns.inherit_from_reference_key is not None:
+                    reference_key = (
+                        self.expected_result_columns.inherit_from_reference_key
+                    )
+                    expected_columns = set(input_data.columns) | set(
+                        reference_data[reference_key].columns
+                    )
+                else:
+                    expected_columns = set(input_data.columns)
+            case "none":
+                columns = [
+                    column
+                    for column in result.columns
+                    if column != result.geometry.name
+                ]
+                if columns:
+                    msg = f"Expected no columns in result, found: {columns}"
+                    raise AssertionError(msg)
+                return
+
+        missing_columns = expected_columns - result_columns
+        if missing_columns:
+            msg = f"Output data is missing columns: {sorted(missing_columns)}"
+            raise AssertionError(msg)
+
+        unexpected_columns = (
+            result_columns - expected_columns - acceptable_extra_columns
+        )
+        if unexpected_columns:
+            msg = f"Output data has unexpected columns: {sorted(unexpected_columns)}"
+            raise AssertionError(msg)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -342,13 +342,10 @@ class IntegrationTest:
             attribute_data,
             index=[str(uuid4())],
             geometry=[
-                dummy_geometry(next(iter(self.algorithm.valid_input_geometry_types)))
+                dummy_geometry(min(self.algorithm.valid_input_geometry_types)),
             ],
             crs="EPSG:3857",
         )
-
-        # TODO: selecting next from a set is non-deterministic potentially
-        # resulting in flaky tests?
 
         reference_data = {}
         for key, ref in self.algorithm.reference_data_schema.items():
@@ -359,7 +356,7 @@ class IntegrationTest:
             reference_data[getattr(self.algorithm, key)] = GeoDataFrame(
                 reference_attributes,
                 index=[str(uuid4())],
-                geometry=[dummy_geometry(next(iter(ref.valid_geometry_types)))],
+                geometry=[dummy_geometry(min(ref.valid_geometry_types))],
                 crs="EPSG:3857",
             )
 


### PR DESCRIPTION
## Description <!-- markdownlint-disable-line MD041 -->

Enable defining what columns an `IntegrationTest` result should have. Currently supported "inheritance" modes are `input` where columns have to be the same as in the input data, `input_and_ref` where columns have to be the same as in the input data AND a reference GDF (needed for water areas because of the inclusion of shoreline features), and `empty` where the output GDF must have no columns except geometry (needed for building areas).

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Other

- [x] Non-breaking change
- [ ] Breaking change

## Developer checklist <!-- markdownlint-disable-line MD041 -->

- [ ] A [CHANGELOG entry] has been included (only when change is visible to users)

[CHANGELOG entry]: https://github.com/nlsfi/geogen-algorithms/blob/main/CHANGELOG.md
